### PR TITLE
회원정보 수정

### DIFF
--- a/src/main/java/com/flab/shoeauction/common/utils/certification/coolSms/SmsMessageTemplate.java
+++ b/src/main/java/com/flab/shoeauction/common/utils/certification/coolSms/SmsMessageTemplate.java
@@ -1,14 +1,14 @@
 package com.flab.shoeauction.common.utils.certification.coolSms;
 
 public class SmsMessageTemplate {
-    public String getCertificationContent(String certificationNumber) {
+    public String builderCertificationContent(String certificationNumber) {
 
-        StringBuilder bd = new StringBuilder();
-        bd.append("[Shoe-Auction] 인증번호는 ");
-        bd.append(certificationNumber);
-        bd.append("입니다. ");
+        StringBuilder builder = new StringBuilder();
+        builder.append("[Shoe-Auction] 인증번호는 ");
+        builder.append(certificationNumber);
+        builder.append("입니다. ");
 
-        return bd.toString();
+        return builder.toString();
     }
 
 }

--- a/src/main/java/com/flab/shoeauction/common/utils/certification/coolSms/SmsMessageTemplate.java
+++ b/src/main/java/com/flab/shoeauction/common/utils/certification/coolSms/SmsMessageTemplate.java
@@ -2,7 +2,13 @@ package com.flab.shoeauction.common.utils.certification.coolSms;
 
 public class SmsMessageTemplate {
     public String getCertificationContent(String certificationNumber) {
-        return String.format("%s%s%s", "[Shoe-Auction] 인증번호는 ",certificationNumber,"입니다.");
+
+        StringBuilder bd = new StringBuilder();
+        bd.append("[Shoe-Auction] 인증번호는 ");
+        bd.append(certificationNumber);
+        bd.append("입니다. ");
+
+        return bd.toString();
     }
 
 }

--- a/src/main/java/com/flab/shoeauction/common/utils/certification/coolSms/coolSmsConstants.java
+++ b/src/main/java/com/flab/shoeauction/common/utils/certification/coolSms/coolSmsConstants.java
@@ -1,6 +1,6 @@
 package com.flab.shoeauction.common.utils.certification.coolSms;
 
 public class coolSmsConstants {
-    public static String SMS_TYPE = "text";
-    public static String APP_VERSION = "test app 1.2";
+    public static final String SMS_TYPE = "text";
+    public static final String APP_VERSION = "test app 1.2";
 }

--- a/src/main/java/com/flab/shoeauction/common/utils/certification/email/EmailContentTemplate.java
+++ b/src/main/java/com/flab/shoeauction/common/utils/certification/email/EmailContentTemplate.java
@@ -3,7 +3,13 @@ package com.flab.shoeauction.common.utils.certification.email;
 public class EmailContentTemplate {
 
     public String getCertificationContent(String certificationNumber) {
-        return String.format("%s%s%s", "[Shoe-Auction] 인증번호는 ",certificationNumber,"입니다.");
+
+        StringBuilder bd = new StringBuilder();
+        bd.append("[Shoe-Auction] 인증번호는 ");
+        bd.append(certificationNumber);
+        bd.append("입니다. ");
+
+        return bd.toString();
     }
 
 }

--- a/src/main/java/com/flab/shoeauction/common/utils/certification/email/EmailContentTemplate.java
+++ b/src/main/java/com/flab/shoeauction/common/utils/certification/email/EmailContentTemplate.java
@@ -2,14 +2,14 @@ package com.flab.shoeauction.common.utils.certification.email;
 
 public class EmailContentTemplate {
 
-    public String getCertificationContent(String certificationNumber) {
+    public String buildCertificationContent(String certificationNumber) {
 
-        StringBuilder bd = new StringBuilder();
-        bd.append("[Shoe-Auction] 인증번호는 ");
-        bd.append(certificationNumber);
-        bd.append("입니다. ");
+        StringBuilder builder = new StringBuilder();
+        builder.append("[Shoe-Auction] 인증번호는 ");
+        builder.append(certificationNumber);
+        builder.append("입니다. ");
 
-        return bd.toString();
+        return builder.toString();
     }
 
 }

--- a/src/main/java/com/flab/shoeauction/common/utils/response/ResponseConstants.java
+++ b/src/main/java/com/flab/shoeauction/common/utils/response/ResponseConstants.java
@@ -2,7 +2,6 @@ package com.flab.shoeauction.common.utils.response;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.client.HttpClientErrorException.Unauthorized;
 
 public class ResponseConstants {
 
@@ -25,8 +24,15 @@ public class ResponseConstants {
         new ResponseEntity<>(
             "가입하지 않은 아이디이거나, 잘못된 비밀번호입니다.", HttpStatus.BAD_REQUEST
         );
+
     public static final ResponseEntity<String> UNAUTHORIZED_USER =
         new ResponseEntity<>(
             "Unauthenticated user", HttpStatus.UNAUTHORIZED
         );
+
+    public static final ResponseEntity FAIL_TO_CHANGE_NICKNAME =
+        new ResponseEntity<>(
+            "닉네임은 7일에 한번만 변경이 가능합니다.", HttpStatus.BAD_REQUEST
+        );
+
 }

--- a/src/main/java/com/flab/shoeauction/controller/UserApiController.java
+++ b/src/main/java/com/flab/shoeauction/controller/UserApiController.java
@@ -177,4 +177,11 @@ public class UserApiController {
         userService.updateAddressBook(requestDto);
         return OK;
     }
+
+    @LoginCheck
+    @PatchMapping("/nickname")
+    public ResponseEntity updateNickname(@CurrentUser String email,@RequestBody SaveRequest requestDto) {
+        userService.updateNickname(email,requestDto);
+        return OK;
+    }
 }

--- a/src/main/java/com/flab/shoeauction/controller/UserApiController.java
+++ b/src/main/java/com/flab/shoeauction/controller/UserApiController.java
@@ -5,7 +5,7 @@ import static com.flab.shoeauction.common.utils.response.ResponseConstants.OK;
 
 import com.flab.shoeauction.common.annotation.CurrentUser;
 import com.flab.shoeauction.common.annotation.LoginCheck;
-import com.flab.shoeauction.controller.dto.UserDto.ChangeAccountRequest;
+import com.flab.shoeauction.controller.dto.UserDto.ChangeAddressRequest;
 import com.flab.shoeauction.controller.dto.UserDto.ChangePasswordRequest;
 import com.flab.shoeauction.controller.dto.UserDto.EmailCertificationRequest;
 import com.flab.shoeauction.controller.dto.UserDto.FindUserResponse;
@@ -13,10 +13,14 @@ import com.flab.shoeauction.controller.dto.UserDto.LoginRequest;
 import com.flab.shoeauction.controller.dto.UserDto.SaveRequest;
 import com.flab.shoeauction.controller.dto.UserDto.SmsCertificationRequest;
 import com.flab.shoeauction.controller.dto.UserDto.UserInfoDto;
-import com.flab.shoeauction.service.certification.EmailCertificationService;
+import com.flab.shoeauction.domain.AddressBook.Address;
+import com.flab.shoeauction.domain.AddressBook.AddressBook;
+import com.flab.shoeauction.domain.user.Account;
 import com.flab.shoeauction.service.LoginService;
-import com.flab.shoeauction.service.certification.SmsCertificationService;
 import com.flab.shoeauction.service.UserService;
+import com.flab.shoeauction.service.certification.EmailCertificationService;
+import com.flab.shoeauction.service.certification.SmsCertificationService;
+import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -133,10 +137,44 @@ public class UserApiController {
     @LoginCheck
     @PatchMapping("/account")
     public ResponseEntity changeAccount(@CurrentUser String email, @RequestBody
-        ChangeAccountRequest requestDto) {
-        userService.updateAccount(email, requestDto);
+        Account account) {
+        userService.updateAccount(email, account);
         return OK;
     }
 
+    @LoginCheck
+    @GetMapping("/account")
+    public ResponseEntity<Account> getAccountResource(@CurrentUser String email) {
+        Account account = userService.getAccount(email);
+        return ResponseEntity.ok(account);
+    }
 
+
+    @LoginCheck
+    @PostMapping("/addressBook")
+    public ResponseEntity addAddressBook(@CurrentUser String email, @RequestBody Address address) {
+        userService.addAddressBook(email,address);
+        return OK;
+    }
+
+    @LoginCheck
+    @GetMapping("/addressBook")
+    public ResponseEntity<List<AddressBook>> getAddressBookResource(@CurrentUser String email) {
+        List<AddressBook> addressBooks = userService.getAddressBooks(email);
+        return ResponseEntity.ok(addressBooks);
+    }
+
+    @LoginCheck
+    @DeleteMapping("/addressBook")
+    public ResponseEntity deleteAddressBook(@RequestBody ChangeAddressRequest requestDto) {
+        userService.deleteAddressBook(requestDto);
+        return OK;
+    }
+
+    @LoginCheck
+    @PatchMapping("/addressBook")
+    public ResponseEntity updateAddressBook(@RequestBody ChangeAddressRequest requestDto) {
+        userService.updateAddressBook(requestDto);
+        return OK;
+    }
 }

--- a/src/main/java/com/flab/shoeauction/controller/UserApiController.java
+++ b/src/main/java/com/flab/shoeauction/controller/UserApiController.java
@@ -5,7 +5,7 @@ import static com.flab.shoeauction.common.utils.response.ResponseConstants.OK;
 
 import com.flab.shoeauction.common.annotation.CurrentUser;
 import com.flab.shoeauction.common.annotation.LoginCheck;
-import com.flab.shoeauction.controller.dto.UserDto.ChangeAddressRequest;
+import com.flab.shoeauction.controller.dto.AddressBookDto;
 import com.flab.shoeauction.controller.dto.UserDto.ChangePasswordRequest;
 import com.flab.shoeauction.controller.dto.UserDto.EmailCertificationRequest;
 import com.flab.shoeauction.controller.dto.UserDto.FindUserResponse;
@@ -75,17 +75,15 @@ public class UserApiController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity login(@RequestBody LoginRequest loginRequest) {
+    public void login(@RequestBody LoginRequest loginRequest) {
         loginService.existByEmailAndPassword(loginRequest);
         loginService.login(loginRequest.getEmail());
-        return OK;
     }
 
     @LoginCheck
     @DeleteMapping("/logout")
-    public ResponseEntity logout() {
+    public void logout() {
         loginService.logout();
-        return OK;
     }
 
     @LoginCheck
@@ -112,34 +110,28 @@ public class UserApiController {
     }
 
     @PostMapping("/email-certification/confirms")
-    public ResponseEntity emailVerification(@RequestBody EmailCertificationRequest requestDto) {
+    public void emailVerification(@RequestBody EmailCertificationRequest requestDto) {
         emailCertificationService.verifyEmail(requestDto);
-        return OK;
-
     }
 
-    // TODO: 2021-02-03 : URI 네이밍 고민
-    @PatchMapping("/password-nonLogin")
-    public ResponseEntity changePassword_nonLogin(
+    @PatchMapping("/forget/password")
+    public void changePasswordByForget(
         @Valid @RequestBody ChangePasswordRequest requestDto) {
         userService.updatePasswordByForget(requestDto);
-        return OK;
     }
 
     @LoginCheck
     @PatchMapping("/password")
-    public ResponseEntity changePassword(@CurrentUser String email,
+    public void changePassword(@CurrentUser String email,
         @Valid @RequestBody ChangePasswordRequest requestDto) {
         userService.updatePassword(email, requestDto);
-        return OK;
     }
 
     @LoginCheck
     @PatchMapping("/account")
-    public ResponseEntity changeAccount(@CurrentUser String email, @RequestBody
+    public void changeAccount(@CurrentUser String email, @RequestBody
         Account account) {
         userService.updateAccount(email, account);
-        return OK;
     }
 
     @LoginCheck
@@ -152,9 +144,8 @@ public class UserApiController {
 
     @LoginCheck
     @PostMapping("/addressBook")
-    public ResponseEntity addAddressBook(@CurrentUser String email, @RequestBody Address address) {
+    public void addAddressBook(@CurrentUser String email, @RequestBody Address address) {
         userService.addAddressBook(email,address);
-        return OK;
     }
 
     @LoginCheck
@@ -166,22 +157,19 @@ public class UserApiController {
 
     @LoginCheck
     @DeleteMapping("/addressBook")
-    public ResponseEntity deleteAddressBook(@RequestBody ChangeAddressRequest requestDto) {
+    public void deleteAddressBook(@RequestBody AddressBookDto requestDto) {
         userService.deleteAddressBook(requestDto);
-        return OK;
     }
 
     @LoginCheck
     @PatchMapping("/addressBook")
-    public ResponseEntity updateAddressBook(@RequestBody ChangeAddressRequest requestDto) {
+    public void updateAddressBook(@RequestBody AddressBookDto requestDto) {
         userService.updateAddressBook(requestDto);
-        return OK;
     }
 
     @LoginCheck
     @PatchMapping("/nickname")
-    public ResponseEntity updateNickname(@CurrentUser String email,@RequestBody SaveRequest requestDto) {
+    public void updateNickname(@CurrentUser String email,@RequestBody SaveRequest requestDto) {
         userService.updateNickname(email,requestDto);
-        return OK;
     }
 }

--- a/src/main/java/com/flab/shoeauction/controller/UserApiController.java
+++ b/src/main/java/com/flab/shoeauction/controller/UserApiController.java
@@ -91,10 +91,10 @@ public class UserApiController {
     }
 
     /**
-    비밀번호 찾기 : 이메일 입력시, 존재하는 이메일이면 휴대폰인증과 이메일인증 중 택1 하도록 구현
-    휴대폰 인증 선택시 : sendSms / SmsVerification 핸들러
-    이메일 인증 선택시 : sendEmail / emailVerification 핸들러
-    */
+     비밀번호 찾기 : 이메일 입력시, 존재하는 이메일이면 휴대폰인증과 이메일인증 중 택1 하도록 구현
+     휴대폰 인증 선택시 : sendSms / SmsVerification 핸들러
+     이메일 인증 선택시 : sendEmail / emailVerification 핸들러
+     */
     @GetMapping("/find/{email}")
     public ResponseEntity<FindUserResponse> findUser(@PathVariable String email) {
         FindUserResponse findUserResponse = userService.getUserResource(email);
@@ -114,9 +114,19 @@ public class UserApiController {
 
     }
     // TODO: 2021-02-03 : URI 네이밍 고민
-    @PatchMapping("password-nonLogin")
+    @PatchMapping("/password-nonLogin")
     public ResponseEntity changePassword_nonLogin(@Valid @RequestBody ChangePasswordRequest requestDto) {
-        userService.updatePassword(requestDto);
+        userService.updatePasswordByForget(requestDto);
         return OK;
     }
+
+    @LoginCheck
+    @PatchMapping("/password")
+    public ResponseEntity changePassword(@CurrentUser String email, @Valid @RequestBody ChangePasswordRequest requestDto) {
+        userService.updatePassword(email,requestDto);
+        return OK;
+    }
+
+
+
 }

--- a/src/main/java/com/flab/shoeauction/controller/UserApiController.java
+++ b/src/main/java/com/flab/shoeauction/controller/UserApiController.java
@@ -5,6 +5,7 @@ import static com.flab.shoeauction.common.utils.response.ResponseConstants.OK;
 
 import com.flab.shoeauction.common.annotation.CurrentUser;
 import com.flab.shoeauction.common.annotation.LoginCheck;
+import com.flab.shoeauction.controller.dto.UserDto.ChangeAccountRequest;
 import com.flab.shoeauction.controller.dto.UserDto.ChangePasswordRequest;
 import com.flab.shoeauction.controller.dto.UserDto.EmailCertificationRequest;
 import com.flab.shoeauction.controller.dto.UserDto.FindUserResponse;
@@ -91,9 +92,8 @@ public class UserApiController {
     }
 
     /**
-     비밀번호 찾기 : 이메일 입력시, 존재하는 이메일이면 휴대폰인증과 이메일인증 중 택1 하도록 구현
-     휴대폰 인증 선택시 : sendSms / SmsVerification 핸들러
-     이메일 인증 선택시 : sendEmail / emailVerification 핸들러
+     * 비밀번호 찾기 : 이메일 입력시, 존재하는 이메일이면 휴대폰인증과 이메일인증 중 택1 하도록 구현 휴대폰 인증 선택시 : sendSms / SmsVerification
+     * 핸들러 이메일 인증 선택시 : sendEmail / emailVerification 핸들러
      */
     @GetMapping("/find/{email}")
     public ResponseEntity<FindUserResponse> findUser(@PathVariable String email) {
@@ -113,20 +113,30 @@ public class UserApiController {
         return OK;
 
     }
+
     // TODO: 2021-02-03 : URI 네이밍 고민
     @PatchMapping("/password-nonLogin")
-    public ResponseEntity changePassword_nonLogin(@Valid @RequestBody ChangePasswordRequest requestDto) {
+    public ResponseEntity changePassword_nonLogin(
+        @Valid @RequestBody ChangePasswordRequest requestDto) {
         userService.updatePasswordByForget(requestDto);
         return OK;
     }
 
     @LoginCheck
     @PatchMapping("/password")
-    public ResponseEntity changePassword(@CurrentUser String email, @Valid @RequestBody ChangePasswordRequest requestDto) {
-        userService.updatePassword(email,requestDto);
+    public ResponseEntity changePassword(@CurrentUser String email,
+        @Valid @RequestBody ChangePasswordRequest requestDto) {
+        userService.updatePassword(email, requestDto);
         return OK;
     }
 
+    @LoginCheck
+    @PatchMapping("/account")
+    public ResponseEntity changeAccount(@CurrentUser String email, @RequestBody
+        ChangeAccountRequest requestDto) {
+        userService.updateAccount(email, requestDto);
+        return OK;
+    }
 
 
 }

--- a/src/main/java/com/flab/shoeauction/controller/dto/AddressBookDto.java
+++ b/src/main/java/com/flab/shoeauction/controller/dto/AddressBookDto.java
@@ -1,0 +1,17 @@
+package com.flab.shoeauction.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AddressBookDto {
+
+    private Long id;
+    private String addressName;
+    private String roadNameAddress;
+    private String detailedAddress;
+    private String postalCode;
+
+
+}

--- a/src/main/java/com/flab/shoeauction/controller/dto/UserDto.java
+++ b/src/main/java/com/flab/shoeauction/controller/dto/UserDto.java
@@ -2,7 +2,7 @@ package com.flab.shoeauction.controller.dto;
 
 import com.flab.shoeauction.domain.user.User;
 import com.flab.shoeauction.domain.user.Account;
-import com.flab.shoeauction.domain.user.Address;
+import com.flab.shoeauction.domain.AddressBook.Address;
 import com.flab.shoeauction.service.encrytion.EncryptionService;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
@@ -140,6 +140,20 @@ public class UserDto {
         public static ChangePasswordRequest of(String email, String newPassword, String existingPassword) {
             return new ChangePasswordRequest(email, newPassword,existingPassword);
         }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class ChangeAccountRequest {
+        private String bankName;
+        private String accountNumber;
+        private String depositor;
+
+        public static ChangeAccountRequest of(String bankName, String accountNumber, String depositor) {
+            return new ChangeAccountRequest(bankName, accountNumber, depositor);
+        }
+
+
     }
 
 

--- a/src/main/java/com/flab/shoeauction/controller/dto/UserDto.java
+++ b/src/main/java/com/flab/shoeauction/controller/dto/UserDto.java
@@ -142,20 +142,5 @@ public class UserDto {
         }
     }
 
-    @Getter
-    @AllArgsConstructor
-    public static class ChangeAddressRequest {
-        private Long id;
-        private String addressName;
-        private String roadNameAddress;
-        private String detailedAddress;
-        private String postalCode;
-
-
-        public static ChangeAddressRequest of(Long id, String addressName, String roadNameAddress, String detailedAddress, String postalCode) {
-            return new ChangeAddressRequest(id,addressName,roadNameAddress,detailedAddress,postalCode);
-        }
-
-    }
 
 }

--- a/src/main/java/com/flab/shoeauction/controller/dto/UserDto.java
+++ b/src/main/java/com/flab/shoeauction/controller/dto/UserDto.java
@@ -130,8 +130,6 @@ public class UserDto {
 
         private String passwordBefore;
 
-
-
         public void passwordEncryption(EncryptionService encryptionService) {
             this.passwordAfter = encryptionService.encrypt(passwordAfter);
             this.passwordBefore = encryptionService.encrypt(passwordBefore);
@@ -143,18 +141,12 @@ public class UserDto {
     }
 
     @Getter
-    @AllArgsConstructor
-    public static class ChangeAccountRequest {
-        private String bankName;
-        private String accountNumber;
-        private String depositor;
-
-        public static ChangeAccountRequest of(String bankName, String accountNumber, String depositor) {
-            return new ChangeAccountRequest(bankName, accountNumber, depositor);
-        }
-
-
+    public static class ChangeAddressRequest {
+        private Long id;
+        private String addressName;
+        private String roadNameAddress;
+        private String detailedAddress;
+        private String postalCode;
     }
-
 
 }

--- a/src/main/java/com/flab/shoeauction/controller/dto/UserDto.java
+++ b/src/main/java/com/flab/shoeauction/controller/dto/UserDto.java
@@ -126,14 +126,19 @@ public class UserDto {
 
         @NotBlank(message = "비밀번호를 입력해주세요.")
         @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하로 입력해주세요.")
-        private String password;
+        private String passwordAfter;
+
+        private String passwordBefore;
+
+
 
         public void passwordEncryption(EncryptionService encryptionService) {
-            this.password = encryptionService.encrypt(password);
+            this.passwordAfter = encryptionService.encrypt(passwordAfter);
+            this.passwordBefore = encryptionService.encrypt(passwordBefore);
         }
 
-        public static ChangePasswordRequest of(String email, String password) {
-            return new ChangePasswordRequest(email, password);
+        public static ChangePasswordRequest of(String email, String newPassword, String existingPassword) {
+            return new ChangePasswordRequest(email, newPassword,existingPassword);
         }
     }
 

--- a/src/main/java/com/flab/shoeauction/controller/dto/UserDto.java
+++ b/src/main/java/com/flab/shoeauction/controller/dto/UserDto.java
@@ -4,6 +4,7 @@ import com.flab.shoeauction.domain.user.User;
 import com.flab.shoeauction.domain.user.Account;
 import com.flab.shoeauction.domain.AddressBook.Address;
 import com.flab.shoeauction.service.encrytion.EncryptionService;
+import java.time.LocalDateTime;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
@@ -56,6 +57,7 @@ public class UserDto {
                 .nickname(this.nickname)
                 .email(this.email)
                 .password(this.password)
+                .nicknameModifiedDate(LocalDateTime.now())
                 .phone(this.phone)
                 .build();
         }

--- a/src/main/java/com/flab/shoeauction/controller/dto/UserDto.java
+++ b/src/main/java/com/flab/shoeauction/controller/dto/UserDto.java
@@ -137,18 +137,25 @@ public class UserDto {
             this.passwordBefore = encryptionService.encrypt(passwordBefore);
         }
 
-        public static ChangePasswordRequest of(String email, String newPassword, String existingPassword) {
-            return new ChangePasswordRequest(email, newPassword,existingPassword);
+        public static ChangePasswordRequest of(String email, String passwordAfter, String passwordBefore) {
+            return new ChangePasswordRequest(email, passwordAfter,passwordBefore);
         }
     }
 
     @Getter
+    @AllArgsConstructor
     public static class ChangeAddressRequest {
         private Long id;
         private String addressName;
         private String roadNameAddress;
         private String detailedAddress;
         private String postalCode;
+
+
+        public static ChangeAddressRequest of(Long id, String addressName, String roadNameAddress, String detailedAddress, String postalCode) {
+            return new ChangeAddressRequest(id,addressName,roadNameAddress,detailedAddress,postalCode);
+        }
+
     }
 
 }

--- a/src/main/java/com/flab/shoeauction/domain/AddressBook/Address.java
+++ b/src/main/java/com/flab/shoeauction/domain/AddressBook/Address.java
@@ -1,20 +1,21 @@
-package com.flab.shoeauction.domain.user;
+package com.flab.shoeauction.domain.AddressBook;
 
+import javax.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import javax.persistence.Embeddable;
 
 /**
  * 도로명 주소,상세주소
  */
 
-@Embeddable
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
 public class Address {
 
+    private String addressName;
     private String roadNameAddress;
     private String detailedAddress;
+    private String postalCode;
 }

--- a/src/main/java/com/flab/shoeauction/domain/AddressBook/Address.java
+++ b/src/main/java/com/flab/shoeauction/domain/AddressBook/Address.java
@@ -1,6 +1,6 @@
 package com.flab.shoeauction.domain.AddressBook;
 
-import com.flab.shoeauction.controller.dto.UserDto.ChangeAddressRequest;
+import com.flab.shoeauction.controller.dto.AddressBookDto;
 import javax.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -22,7 +22,7 @@ public class Address {
     private String detailedAddress;
     private String postalCode;
 
-    public void updateAddress(ChangeAddressRequest requestDto) {
+    public void updateAddress(AddressBookDto requestDto) {
         this.addressName = requestDto.getAddressName();
         this.roadNameAddress = requestDto.getRoadNameAddress();
         this.detailedAddress = requestDto.getDetailedAddress();

--- a/src/main/java/com/flab/shoeauction/domain/AddressBook/Address.java
+++ b/src/main/java/com/flab/shoeauction/domain/AddressBook/Address.java
@@ -2,6 +2,7 @@ package com.flab.shoeauction.domain.AddressBook;
 
 import com.flab.shoeauction.controller.dto.UserDto.ChangeAddressRequest;
 import javax.persistence.Embeddable;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,7 +12,7 @@ import lombok.NoArgsConstructor;
  */
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Embeddable
 public class Address {

--- a/src/main/java/com/flab/shoeauction/domain/AddressBook/Address.java
+++ b/src/main/java/com/flab/shoeauction/domain/AddressBook/Address.java
@@ -1,7 +1,8 @@
 package com.flab.shoeauction.domain.AddressBook;
 
+import com.flab.shoeauction.controller.dto.UserDto.ChangeAddressRequest;
 import javax.persistence.Embeddable;
-import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,7 +11,8 @@ import lombok.NoArgsConstructor;
  */
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
+@AllArgsConstructor
 @Embeddable
 public class Address {
 
@@ -18,4 +20,11 @@ public class Address {
     private String roadNameAddress;
     private String detailedAddress;
     private String postalCode;
+
+    public void updateAddress(ChangeAddressRequest requestDto) {
+        this.addressName = requestDto.getAddressName();
+        this.roadNameAddress = requestDto.getRoadNameAddress();
+        this.detailedAddress = requestDto.getDetailedAddress();
+        this.postalCode = requestDto.getPostalCode();
+    }
 }

--- a/src/main/java/com/flab/shoeauction/domain/AddressBook/AddressBook.java
+++ b/src/main/java/com/flab/shoeauction/domain/AddressBook/AddressBook.java
@@ -1,12 +1,11 @@
 package com.flab.shoeauction.domain.AddressBook;
 
-import com.flab.shoeauction.controller.dto.UserDto.ChangeAddressRequest;
+import com.flab.shoeauction.controller.dto.AddressBookDto;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,7 +27,7 @@ public class AddressBook {
         this.address = address;
     }
 
-    public void updateAddressBook(ChangeAddressRequest requestDto){
+    public void updateAddressBook(AddressBookDto requestDto){
         address.updateAddress(requestDto);
     }
 

--- a/src/main/java/com/flab/shoeauction/domain/AddressBook/AddressBook.java
+++ b/src/main/java/com/flab/shoeauction/domain/AddressBook/AddressBook.java
@@ -1,12 +1,12 @@
 package com.flab.shoeauction.domain.AddressBook;
 
 import com.flab.shoeauction.controller.dto.UserDto.ChangeAddressRequest;
-import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,7 +18,6 @@ public class AddressBook {
 
     @Id
     @GeneratedValue
-    @Column(name="ADDRESSBOOK_ID")
     private Long id;
 
     @Embedded

--- a/src/main/java/com/flab/shoeauction/domain/AddressBook/AddressBook.java
+++ b/src/main/java/com/flab/shoeauction/domain/AddressBook/AddressBook.java
@@ -1,0 +1,18 @@
+package com.flab.shoeauction.domain.AddressBook;
+
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class AddressBook {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Embedded
+    private Address address;
+
+}

--- a/src/main/java/com/flab/shoeauction/domain/AddressBook/AddressBook.java
+++ b/src/main/java/com/flab/shoeauction/domain/AddressBook/AddressBook.java
@@ -1,18 +1,37 @@
 package com.flab.shoeauction.domain.AddressBook;
 
+import com.flab.shoeauction.controller.dto.UserDto.ChangeAddressRequest;
+import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AddressBook {
 
     @Id
     @GeneratedValue
+    @Column(name="ADDRESSBOOK_ID")
     private Long id;
 
     @Embedded
     private Address address;
+
+    @Builder
+    public AddressBook(Address address) {
+        this.address = address;
+    }
+
+    public void updateAddressBook(ChangeAddressRequest requestDto){
+        address.updateAddress(requestDto);
+    }
+
 
 }

--- a/src/main/java/com/flab/shoeauction/domain/AddressBook/AddressBookRepository.java
+++ b/src/main/java/com/flab/shoeauction/domain/AddressBook/AddressBookRepository.java
@@ -1,0 +1,7 @@
+package com.flab.shoeauction.domain.AddressBook;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AddressBookRepository extends JpaRepository<AddressBook, Long> {
+
+}

--- a/src/main/java/com/flab/shoeauction/domain/user/Account.java
+++ b/src/main/java/com/flab/shoeauction/domain/user/Account.java
@@ -1,6 +1,7 @@
 package com.flab.shoeauction.domain.user;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,8 +14,10 @@ import javax.persistence.Embeddable;
 @Embeddable
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Account {
 
+    private String bankName;
     private String accountNumber;
     private String depositor;
 }

--- a/src/main/java/com/flab/shoeauction/domain/user/User.java
+++ b/src/main/java/com/flab/shoeauction/domain/user/User.java
@@ -42,9 +42,6 @@ public class User extends BaseTimeEntity {
     private String phone;
 
     @Embedded
-    private Address address;
-
-    @Embedded
     private Account account;
 
 
@@ -57,7 +54,6 @@ public class User extends BaseTimeEntity {
             .email(this.getEmail())
             .nickname(this.getNickname())
             .phone(this.getPhone())
-            .address(this.getAddress())
             .account(this.getAccount())
             .build();
     }
@@ -69,13 +65,15 @@ public class User extends BaseTimeEntity {
             .build();
     }
 
-
     public void updatePassword(String password) {
         this.password = password;
     }
 
-    public void updateAccount(String bankName, String accountNumber, String depositor) {
-        Account account = new Account(bankName, accountNumber, depositor);
+    public void updateAccount(Account account) {
         this.account = account;
+    }
+
+    public void updateAddressBook(Address address) {
+        this.addressesBook.add(new AddressBook(address));
     }
 }

--- a/src/main/java/com/flab/shoeauction/domain/user/User.java
+++ b/src/main/java/com/flab/shoeauction/domain/user/User.java
@@ -78,7 +78,7 @@ public class User extends BaseTimeEntity {
         this.account = account;
     }
 
-    public void updateAddressBook(Address address) {
+    public void addAddressBook(Address address) {
         this.addressesBook.add(new AddressBook(address));
     }
 

--- a/src/main/java/com/flab/shoeauction/domain/user/User.java
+++ b/src/main/java/com/flab/shoeauction/domain/user/User.java
@@ -2,12 +2,19 @@ package com.flab.shoeauction.domain.user;
 
 import com.flab.shoeauction.controller.dto.UserDto.FindUserResponse;
 import com.flab.shoeauction.controller.dto.UserDto.UserInfoDto;
+import com.flab.shoeauction.domain.AddressBook.Address;
+import com.flab.shoeauction.domain.AddressBook.AddressBook;
 import com.flab.shoeauction.domain.BaseTimeEntity;
-import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,6 +30,7 @@ public class User extends BaseTimeEntity {
 
     @Id
     @GeneratedValue
+    @Column(name ="USER_ID")
     private Long id;
 
     private String nickname;
@@ -39,8 +47,10 @@ public class User extends BaseTimeEntity {
     @Embedded
     private Account account;
 
-    private LocalDateTime emailSendDate;
 
+    @OneToMany(cascade= CascadeType.ALL , orphanRemoval = true)
+    @JoinColumn(name ="USER_ID")
+    private List<AddressBook> addressesBook = new ArrayList<>();
 
     public UserInfoDto toUserInfoDto() {
         return UserInfoDto.builder()
@@ -62,5 +72,10 @@ public class User extends BaseTimeEntity {
 
     public void updatePassword(String password) {
         this.password = password;
+    }
+
+    public void updateAccount(String bankName, String accountNumber, String depositor) {
+        Account account = new Account(bankName, accountNumber, depositor);
+        this.account = account;
     }
 }

--- a/src/main/java/com/flab/shoeauction/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flab/shoeauction/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import static com.flab.shoeauction.common.utils.response.ResponseConstants.USER_
 import com.flab.shoeauction.exception.user.AuthenticationNumberMismatchException;
 import com.flab.shoeauction.exception.user.DuplicateEmailException;
 import com.flab.shoeauction.exception.user.DuplicateNicknameException;
+import com.flab.shoeauction.exception.user.UnableToChangeNicknameException;
 import com.flab.shoeauction.exception.user.UnauthenticatedUserException;
 import com.flab.shoeauction.exception.user.UserNotFoundException;
 import java.time.LocalDateTime;
@@ -24,6 +25,7 @@ import org.springframework.web.context.request.WebRequest;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
     @ExceptionHandler(DuplicateEmailException.class)
     public final ResponseEntity<String> duplicateEmailException(DuplicateEmailException exception) {
         log.error("중복된 이메일입니다.", exception);
@@ -31,21 +33,24 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(DuplicateNicknameException.class)
-    public final ResponseEntity<String> duplicateNicknameException(DuplicateNicknameException exception) {
+    public final ResponseEntity<String> duplicateNicknameException(
+        DuplicateNicknameException exception) {
         log.error("중복된 닉네임입니다.", exception);
         return DUPLICATION_NICKNAME;
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public final ResponseEntity<String> methodArgumentNotValidException(MethodArgumentNotValidException exception) {
+    public final ResponseEntity<String> methodArgumentNotValidException(
+        MethodArgumentNotValidException exception) {
         log.error(exception.getFieldError().getDefaultMessage(), exception);
-        return new ResponseEntity<>(exception.getFieldError().getDefaultMessage(), HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(exception.getFieldError().getDefaultMessage(),
+            HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(UserNotFoundException.class)
     public final ResponseEntity<String> handleUserNotFoundException(
         UserNotFoundException ex) {
-        log.debug("로그인 실패 : 존재하지 않는 ID 또는 패스워드 불일치",ex);
+        log.debug("로그인 실패 : 존재하지 않는 ID 또는 패스워드 불일치", ex);
         return USER_NOT_FOUND;
     }
 
@@ -64,4 +69,10 @@ public class GlobalExceptionHandler {
         return BAD_REQUEST;
     }
 
+    @ExceptionHandler(UnableToChangeNicknameException.class)
+    public final ResponseEntity handleUnableToChangeNicknameException(
+        UnableToChangeNicknameException ex) {
+        log.error("닉네임은 7일에 한번만 변경 가능합니다.", ex);
+        return new ResponseEntity<>("닉네임은 7일에 한번만 변경이 가능합니다.", HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/flab/shoeauction/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flab/shoeauction/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.flab.shoeauction.exception;
 import static com.flab.shoeauction.common.utils.response.ResponseConstants.BAD_REQUEST;
 import static com.flab.shoeauction.common.utils.response.ResponseConstants.DUPLICATION_EMAIL;
 import static com.flab.shoeauction.common.utils.response.ResponseConstants.DUPLICATION_NICKNAME;
+import static com.flab.shoeauction.common.utils.response.ResponseConstants.FAIL_TO_CHANGE_NICKNAME;
 import static com.flab.shoeauction.common.utils.response.ResponseConstants.UNAUTHORIZED_USER;
 import static com.flab.shoeauction.common.utils.response.ResponseConstants.USER_NOT_FOUND;
 
@@ -73,6 +74,6 @@ public class GlobalExceptionHandler {
     public final ResponseEntity handleUnableToChangeNicknameException(
         UnableToChangeNicknameException ex) {
         log.error("닉네임은 7일에 한번만 변경 가능합니다.", ex);
-        return new ResponseEntity<>("닉네임은 7일에 한번만 변경이 가능합니다.", HttpStatus.BAD_REQUEST);
+        return FAIL_TO_CHANGE_NICKNAME;
     }
 }

--- a/src/main/java/com/flab/shoeauction/exception/user/UnableToChangeNicknameException.java
+++ b/src/main/java/com/flab/shoeauction/exception/user/UnableToChangeNicknameException.java
@@ -1,0 +1,10 @@
+package com.flab.shoeauction.exception.user;
+
+public class UnableToChangeNicknameException extends RuntimeException {
+
+    public UnableToChangeNicknameException(String message) {
+        super(message);
+    }
+
+
+}

--- a/src/main/java/com/flab/shoeauction/service/LoginService.java
+++ b/src/main/java/com/flab/shoeauction/service/LoginService.java
@@ -5,7 +5,6 @@ import static com.flab.shoeauction.common.utils.user.UserConstants.USER_ID;
 import com.flab.shoeauction.controller.dto.UserDto.LoginRequest;
 import com.flab.shoeauction.controller.dto.UserDto.UserInfoDto;
 import com.flab.shoeauction.domain.user.UserRepository;
-import com.flab.shoeauction.exception.user.UnauthenticatedUserException;
 import com.flab.shoeauction.exception.user.UserNotFoundException;
 import com.flab.shoeauction.service.encrytion.EncryptionService;
 import javax.servlet.http.HttpSession;
@@ -44,6 +43,6 @@ public class LoginService {
     public UserInfoDto getCurrentUser(String email) {
 
         return userRepository.findByEmail(email)
-            .orElseThrow(() -> new UnauthenticatedUserException("error : 인증되지 않은 사용자")).toUserInfoDto();
+            .orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자 입니다.")).toUserInfoDto();
     }
 }

--- a/src/main/java/com/flab/shoeauction/service/UserService.java
+++ b/src/main/java/com/flab/shoeauction/service/UserService.java
@@ -125,4 +125,15 @@ public class UserService {
         AddressBook addressBook = addressBookRepository.findById(addressBookId).orElseThrow();
         addressBook.updateAddressBook(requestDto);
     }
+
+    @Transactional
+    public void updateNickname(String email,SaveRequest requestDto) {
+        User user = userRepository.findByEmail(email)
+            .orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자 입니다."));
+
+        if (checkNicknameDuplicate(requestDto.getNickname())) {
+            throw new DuplicateNicknameException();
+        }
+        user.updateNickname(requestDto);
+    }
 }

--- a/src/main/java/com/flab/shoeauction/service/UserService.java
+++ b/src/main/java/com/flab/shoeauction/service/UserService.java
@@ -50,14 +50,29 @@ public class UserService {
     }
 
     @Transactional
-    public void updatePassword(ChangePasswordRequest requestDto) {
+    public void updatePasswordByForget(ChangePasswordRequest requestDto) {
         String email = requestDto.getEmail();
         requestDto.passwordEncryption(encryptionService);
 
         User user = userRepository.findByEmail(email)
             .orElseThrow(() -> new UnauthenticatedUserException("Unauthenticated user"));
 
-        user.updatePassword(requestDto.getPassword());
+        user.updatePassword(requestDto.getPasswordAfter());
+    }
 
+    @Transactional
+    public void updatePassword(String email, ChangePasswordRequest requestDto) {
+        requestDto.passwordEncryption(encryptionService);
+        String passwordBefore = requestDto.getPasswordBefore();
+        String passwordAfter = requestDto.getPasswordAfter();
+        System.out.println(email);
+        if (!userRepository.existsByEmailAndPassword(email, passwordBefore)) {
+            throw new UnauthenticatedUserException("이전 비밀번호가 일치하지 않습니다.");
+        }
+
+        User user = userRepository.findByEmail(email)
+            .orElseThrow(() -> new UnauthenticatedUserException("Unauthenticated user"));
+
+        user.updatePassword(passwordAfter);
     }
 }

--- a/src/main/java/com/flab/shoeauction/service/UserService.java
+++ b/src/main/java/com/flab/shoeauction/service/UserService.java
@@ -1,5 +1,6 @@
 package com.flab.shoeauction.service;
 
+import com.flab.shoeauction.controller.dto.UserDto.ChangeAccountRequest;
 import com.flab.shoeauction.controller.dto.UserDto.ChangePasswordRequest;
 import com.flab.shoeauction.controller.dto.UserDto.FindUserResponse;
 import com.flab.shoeauction.controller.dto.UserDto.SaveRequest;
@@ -74,5 +75,15 @@ public class UserService {
             .orElseThrow(() -> new UnauthenticatedUserException("Unauthenticated user"));
 
         user.updatePassword(passwordAfter);
+    }
+
+    @Transactional
+    public void updateAccount(String email, ChangeAccountRequest requestDto) {
+        User user = userRepository.findByEmail(email)
+            .orElseThrow(() -> new UnauthenticatedUserException("Unauthenticated user"));
+        String bankName = requestDto.getBankName();
+        String accountNumber = requestDto.getAccountNumber();
+        String depositor = requestDto.getDepositor();
+        user.updateAccount(bankName, accountNumber, depositor);
     }
 }

--- a/src/main/java/com/flab/shoeauction/service/UserService.java
+++ b/src/main/java/com/flab/shoeauction/service/UserService.java
@@ -1,6 +1,6 @@
 package com.flab.shoeauction.service;
 
-import com.flab.shoeauction.controller.dto.UserDto.ChangeAddressRequest;
+import com.flab.shoeauction.controller.dto.AddressBookDto;
 import com.flab.shoeauction.controller.dto.UserDto.ChangePasswordRequest;
 import com.flab.shoeauction.controller.dto.UserDto.FindUserResponse;
 import com.flab.shoeauction.controller.dto.UserDto.SaveRequest;
@@ -113,13 +113,13 @@ public class UserService {
     }
 
     @Transactional
-    public void deleteAddressBook(ChangeAddressRequest requestDto) {
+    public void deleteAddressBook(AddressBookDto requestDto) {
         Long addressBookId = requestDto.getId();
         addressBookRepository.deleteById(addressBookId);
     }
 
     @Transactional
-    public void updateAddressBook(ChangeAddressRequest requestDto) {
+    public void updateAddressBook(AddressBookDto requestDto) {
         Long addressBookId = requestDto.getId();
         AddressBook addressBook = addressBookRepository.findById(addressBookId).orElseThrow();
         addressBook.updateAddressBook(requestDto);

--- a/src/main/java/com/flab/shoeauction/service/UserService.java
+++ b/src/main/java/com/flab/shoeauction/service/UserService.java
@@ -71,7 +71,6 @@ public class UserService {
         requestDto.passwordEncryption(encryptionService);
         String passwordBefore = requestDto.getPasswordBefore();
         String passwordAfter = requestDto.getPasswordAfter();
-        System.out.println(email);
         if (!userRepository.existsByEmailAndPassword(email, passwordBefore)) {
             throw new UnauthenticatedUserException("이전 비밀번호가 일치하지 않습니다.");
         }
@@ -110,7 +109,7 @@ public class UserService {
         User user = userRepository.findByEmail(email)
             .orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자 입니다."));
 
-        user.updateAddressBook(address);
+        user.addAddressBook(address);
     }
 
     @Transactional

--- a/src/main/java/com/flab/shoeauction/service/certification/EmailCertificationService.java
+++ b/src/main/java/com/flab/shoeauction/service/certification/EmailCertificationService.java
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @RequiredArgsConstructor
 @Service
-@ConfigurationProperties("certification-related constants")
+@ConfigurationProperties("certification-related-constants")
 public class EmailCertificationService {
     private final JavaMailSender mailSender;
     private final EmailCertificationDao emailCertificationDao;

--- a/src/main/java/com/flab/shoeauction/service/certification/EmailCertificationService.java
+++ b/src/main/java/com/flab/shoeauction/service/certification/EmailCertificationService.java
@@ -43,7 +43,7 @@ public class EmailCertificationService {
     // 인증 이메일 내용 생성
     public String makeEmailContent(String certificationNumber) {
         EmailContentTemplate content = new EmailContentTemplate();
-        return content.getCertificationContent(certificationNumber);
+        return content.buildCertificationContent(certificationNumber);
     }
 
     // 인증번호 일치 여부 확인

--- a/src/main/java/com/flab/shoeauction/service/certification/SmsCertificationService.java
+++ b/src/main/java/com/flab/shoeauction/service/certification/SmsCertificationService.java
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Service
 @Setter
-@ConfigurationProperties("certification-related constants")
+@ConfigurationProperties("certification-related-constants")
 public class SmsCertificationService {
     private final SmsCertificationDao smsCertificationDao;
 

--- a/src/main/java/com/flab/shoeauction/service/certification/SmsCertificationService.java
+++ b/src/main/java/com/flab/shoeauction/service/certification/SmsCertificationService.java
@@ -34,7 +34,7 @@ public class SmsCertificationService {
     // 인증 메세지 내용 생성
     public String makeSmsContent(String certificationNumber) {
         SmsMessageTemplate content = new SmsMessageTemplate();
-        return content.getCertificationContent(certificationNumber);
+        return content.builderCertificationContent(certificationNumber);
     }
 
     public HashMap<String, String> makeParams(String to, String text) {

--- a/src/test/java/com/flab/shoeauction/service/UserServiceTest.java
+++ b/src/test/java/com/flab/shoeauction/service/UserServiceTest.java
@@ -8,15 +8,24 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.flab.shoeauction.controller.dto.UserDto.ChangeAddressRequest;
 import com.flab.shoeauction.controller.dto.UserDto.ChangePasswordRequest;
 import com.flab.shoeauction.controller.dto.UserDto.FindUserResponse;
 import com.flab.shoeauction.controller.dto.UserDto.SaveRequest;
+import com.flab.shoeauction.domain.AddressBook.Address;
+import com.flab.shoeauction.domain.AddressBook.AddressBook;
+import com.flab.shoeauction.domain.AddressBook.AddressBookRepository;
+import com.flab.shoeauction.domain.user.Account;
 import com.flab.shoeauction.domain.user.User;
 import com.flab.shoeauction.domain.user.UserRepository;
 import com.flab.shoeauction.exception.user.DuplicateEmailException;
 import com.flab.shoeauction.exception.user.DuplicateNicknameException;
+import com.flab.shoeauction.exception.user.UnableToChangeNicknameException;
+import com.flab.shoeauction.exception.user.UnauthenticatedUserException;
 import com.flab.shoeauction.exception.user.UserNotFoundException;
 import com.flab.shoeauction.service.encrytion.EncryptionService;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,10 +47,12 @@ class UserServiceTest {
     UserRepository userRepository;
     @Mock
     EncryptionService encryptionService;
+    @Mock
+    AddressBookRepository addressBookRepository;
     @InjectMocks
     UserService userService;
 
-    private SaveRequest createUser() {
+    private SaveRequest createUserDto() {
         SaveRequest saveRequest = SaveRequest.builder()
             .email("test123@test.com")
             .password("test1234")
@@ -51,11 +62,12 @@ class UserServiceTest {
         return saveRequest;
     }
 
+
     @Test
     @DisplayName("이메일과 닉네임이 중복되지 않으면 회원가입에 성공한다.")
     public void signUp_Successful() {
 
-        SaveRequest saveRequest = createUser();
+        SaveRequest saveRequest = createUserDto();
 
         when(userRepository.existsByEmail("test123@test.com")).thenReturn(false);
         when(userRepository.existsByNickname("17171771")).thenReturn(false);
@@ -68,7 +80,7 @@ class UserServiceTest {
     @Test
     @DisplayName("이메일 중복으로 회원가입에 실패한다.")
     public void emailDuplicate() {
-        SaveRequest saveRequest = createUser();
+        SaveRequest saveRequest = createUserDto();
         when(userRepository.existsByEmail("test123@test.com")).thenReturn(true);
 
         assertThrows(DuplicateEmailException.class, () -> userService.save(saveRequest));
@@ -79,7 +91,7 @@ class UserServiceTest {
     @Test
     @DisplayName("닉네임 중복으로 회원가입에 실패한다.")
     public void nicknameDuplicate() {
-        SaveRequest saveRequest = createUser();
+        SaveRequest saveRequest = createUserDto();
         when(userRepository.existsByNickname("17171771")).thenReturn(true);
 
         assertThrows(DuplicateNicknameException.class, () -> userService.save(saveRequest));
@@ -89,11 +101,12 @@ class UserServiceTest {
 
     @Test
     @DisplayName("비밀번호 찾기 성공 - 전달받은 객체(이메일)가 회원이라면 비밀번호 변경에 성공한다.")
-    public void updatePassword() {
-        ChangePasswordRequest changePasswordRequest = of("test123.test.com", "test12345",null);
-        User user = createUser().toEntity();
+    public void updatePasswordByForget() {
+        ChangePasswordRequest changePasswordRequest = of("test123.test.com", "test12345", null);
+        User user = createUserDto().toEntity();
 
-        when(userRepository.findByEmail(changePasswordRequest.getEmail())).thenReturn(Optional.of(user));
+        when(userRepository.findByEmail(changePasswordRequest.getEmail()))
+            .thenReturn(Optional.of(user));
 
         userService.updatePasswordByForget(changePasswordRequest);
 
@@ -106,7 +119,7 @@ class UserServiceTest {
     @DisplayName("가입된 이메일 입력시 비밀번호 찾기(재설정)에 필요한 리소스를 리턴한다.")
     public void SuccessToGetUserResource() {
         String email = "test123@test.com";
-        User user = createUser().toEntity();
+        User user = createUserDto().toEntity();
 
         when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
 
@@ -125,11 +138,172 @@ class UserServiceTest {
 
         when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
 
-        assertThrows(UserNotFoundException.class, () -> userService.getUserResource("non@test.com"));
+        assertThrows(UserNotFoundException.class,
+            () -> userService.getUserResource("non@test.com"));
 
         verify(userRepository, atLeastOnce()).findByEmail(email);
     }
 
+    @Test
+    @DisplayName("비밀번호 변경 - 이전 비밀번호와 일치하면 비밀번호 변경에 성공한다.")
+    public void updatePassword() {
+        User user = createUserDto().toEntity();
+        ChangePasswordRequest changePasswordRequest = ChangePasswordRequest
+            .of(null, "test12345", "test1234");
+        String email = "test123@test.com";
+        String passwordBefore = encryptionService
+            .encrypt(changePasswordRequest.getPasswordBefore());
+        String passwordAfter = encryptionService.encrypt(changePasswordRequest.getPasswordAfter());
+
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(userRepository.existsByEmailAndPassword(email, passwordBefore)).thenReturn(true);
+
+        userService.updatePassword(email, changePasswordRequest);
+
+        assertThat(user.getPassword()).isEqualTo(passwordAfter);
+
+        verify(userRepository, atLeastOnce()).findByEmail(email);
+        verify(userRepository, atLeastOnce()).existsByEmailAndPassword(email, passwordBefore);
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 - 이전 비밀번호가 일치하지 않으면 비밀번호 변경에 실패한다.")
+    public void failToUpdatePassword() {
+        ChangePasswordRequest changePasswordRequest = ChangePasswordRequest
+            .of(null, "test12345", "test1234");
+        String email = "test123@test.com";
+        String passwordBefore = encryptionService
+            .encrypt(changePasswordRequest.getPasswordBefore());
+
+        when(userRepository.existsByEmailAndPassword(email, passwordBefore)).thenReturn(false);
+
+        assertThrows(UnauthenticatedUserException.class,
+            () -> userService.updatePassword(email, changePasswordRequest));
+
+        verify(userRepository, atLeastOnce()).existsByEmailAndPassword(email, passwordBefore);
+    }
+
+    @Test
+    @DisplayName("계좌 설정 - 환급받을 계좌번호 설정(수정)에 성공한다.")
+    public void updateAccount() {
+        Account account = new Account("카카오뱅크", "123456789", "루루삐");
+        User user = createUserDto().toEntity();
+        String email = "test123@test.com";
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+        userService.updateAccount(email, account);
+
+        assertThat(user.getAccount().getAccountNumber()).isEqualTo(account.getAccountNumber());
+        assertThat(user.getAccount().getBankName()).isEqualTo(account.getBankName());
+        assertThat(user.getAccount().getDepositor()).isEqualTo(account.getDepositor());
+        verify(userRepository, atLeastOnce()).findByEmail(email);
+    }
+
+    @Test
+    @DisplayName("주소록 수정 -주소록에 등록된 주소들 중 하나를 선택하여 수정한다.")
+    public void updateAddressBook() {
+        Address address = new Address("우리집", "땡땡땡로 123", "123동 456호", "12345");
+        AddressBook addressBook = new AddressBook(address);
+        ChangeAddressRequest changeAddressRequest = ChangeAddressRequest
+            .of(2L, "친구집", "사랑로 123", "123-1", "11111");
+        when(addressBookRepository.findById(changeAddressRequest.getId()))
+            .thenReturn(Optional.of(addressBook));
+
+        userService.updateAddressBook(changeAddressRequest);
+
+        assertThat(addressBook.getAddress().getAddressName())
+            .isEqualTo(changeAddressRequest.getAddressName());
+        assertThat(addressBook.getAddress().getDetailedAddress())
+            .isEqualTo(changeAddressRequest.getDetailedAddress());
+        assertThat(addressBook.getAddress().getPostalCode())
+            .isEqualTo(changeAddressRequest.getPostalCode());
+        assertThat(addressBook.getAddress().getRoadNameAddress())
+            .isEqualTo(changeAddressRequest.getRoadNameAddress());
+
+        verify(addressBookRepository, atLeastOnce()).findById(any());
+    }
+
+    @Test
+    @DisplayName("주소록 추가 - 올바른 주소 입력시 주소록 추가에 성공한다.")
+    public void addAddressBook() {
+        ArrayList<AddressBook> addressBooks = new ArrayList<>();
+        User user = User.builder()
+            .email("test123@test.com")
+            .password("test1234")
+            .nickname("17171771")
+            .phone("01020180103")
+            .addressesBook(addressBooks).build();
+        String email = "test123@test.com";
+        Address address = new Address("우리집", "땡땡땡로 123", "111동 111호", "12345");
+        Address address2 = new Address("친구집", "친구집로 123", "222동 222호", "67890");
+        Address address3 = new Address("별장", "해변로 123", "333동 333호", "11111");
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+        userService.addAddressBook(email, address);
+        userService.addAddressBook(email, address2);
+        userService.addAddressBook(email, address3);
+
+        assertThat(user.getAddressesBook().size()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("닉네임 변경 성공 - 중복되지 않은 닉네임을 사용하며 닉네임을 변경한지 7일이 초과되었을 경우 닉네임 변경에 성공한다.")
+    public void failToUpdateNickname() {
+        User user = User.builder()
+            .email("test123@test.com")
+            .nickname("17171771")
+            .nicknameModifiedDate(LocalDateTime.now().minusDays(8))
+            .build();
+        String email = "test123@test.com";
+        SaveRequest requestDto = SaveRequest.builder()
+            .nickname("자우림")
+            .build();
+        String nicknameAfter = requestDto.getNickname();
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNickname(nicknameAfter)).thenReturn(false);
+
+        userService.updateNickname(email,requestDto);
+
+        assertThat(user.getNickname()).isEqualTo(requestDto.getNickname());
+        verify(userRepository, atLeastOnce()).findByEmail(email);
+        verify(userRepository, atLeastOnce()).existsByNickname(nicknameAfter);
+    }
+
+    @Test
+    @DisplayName("닉네임 변경 실패 - 닉네임 중복으로 닉네임 변경에 실패한다.")
+    public void failToUpdateNicknameByDuplicate() {
+        User user = createUserDto().toEntity();
+        String email = "test123@test.com";
+        SaveRequest requestDto = SaveRequest.builder()
+            .nickname("자우림")
+            .build();
+        String nicknameAfter = requestDto.getNickname();
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNickname(nicknameAfter)).thenReturn(true);
+
+        assertThrows(DuplicateNicknameException.class,
+            () -> userService.updateNickname(email, requestDto));
+        verify(userRepository, atLeastOnce()).findByEmail(email);
+        verify(userRepository, atLeastOnce()).existsByNickname(nicknameAfter);
+    }
+
+    @Test
+    @DisplayName("닉네인 변경 실패 - 닉네임을 변경하고 7일이 지나지 않았다면 닉네임 변경에 실패한다.")
+    public void failToUpdateNicknameByTerm() {
+        User user =createUserDto().toEntity();
+        SaveRequest requestDto = SaveRequest.builder()
+            .nickname("자우림")
+            .build();
+        String email = "test123@test.com";
+        String nicknameAfter = requestDto.getNickname();
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNickname(nicknameAfter)).thenReturn(false);
+
+        assertThrows(UnableToChangeNicknameException.class,
+            () -> userService.updateNickname(email, requestDto));
+        verify(userRepository, atLeastOnce()).findByEmail(email);
+        verify(userRepository, atLeastOnce()).existsByNickname(nicknameAfter);
+    }
 
 
 }

--- a/src/test/java/com/flab/shoeauction/service/UserServiceTest.java
+++ b/src/test/java/com/flab/shoeauction/service/UserServiceTest.java
@@ -26,6 +26,7 @@ import com.flab.shoeauction.exception.user.UserNotFoundException;
 import com.flab.shoeauction.service.encrytion.EncryptionService;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -244,6 +245,31 @@ class UserServiceTest {
         userService.addAddressBook(email, address3);
 
         assertThat(user.getAddressesBook().size()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("주소록 조회 - 해당 USER의 주소록을 불러온다.")
+    public void getAddressBooks() {
+        ArrayList<AddressBook> addressBooks = new ArrayList<>();
+        User user = User.builder()
+            .email("test123@test.com")
+            .password("test1234")
+            .nickname("17171771")
+            .phone("01020180103")
+            .addressesBook(addressBooks).build();
+        String email = "test123@test.com";
+        Address address = new Address("우리집", "땡땡땡로 123", "111동 111호", "12345");
+        Address address2 = new Address("친구집", "친구집로 123", "222동 222호", "67890");
+        Address address3 = new Address("별장", "해변로 123", "333동 333호", "11111");
+        user.addAddressBook(address);
+        user.addAddressBook(address2);
+        user.addAddressBook(address3);
+        when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+        List<AddressBook> addressBookList = userService.getAddressBooks(email);
+
+        assertThat(addressBookList.size()).isEqualTo(3);
+        verify(userRepository, atLeastOnce()).findByEmail(email);
     }
 
     @Test

--- a/src/test/java/com/flab/shoeauction/service/UserServiceTest.java
+++ b/src/test/java/com/flab/shoeauction/service/UserServiceTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.flab.shoeauction.controller.dto.UserDto.ChangeAddressRequest;
+import com.flab.shoeauction.controller.dto.AddressBookDto;
 import com.flab.shoeauction.controller.dto.UserDto.ChangePasswordRequest;
 import com.flab.shoeauction.controller.dto.UserDto.FindUserResponse;
 import com.flab.shoeauction.controller.dto.UserDto.SaveRequest;
@@ -205,21 +205,20 @@ class UserServiceTest {
     public void updateAddressBook() {
         Address address = new Address("우리집", "땡땡땡로 123", "123동 456호", "12345");
         AddressBook addressBook = new AddressBook(address);
-        ChangeAddressRequest changeAddressRequest = ChangeAddressRequest
-            .of(2L, "친구집", "사랑로 123", "123-1", "11111");
-        when(addressBookRepository.findById(changeAddressRequest.getId()))
+        AddressBookDto addressBookDto =new AddressBookDto(2L, "친구집", "사랑로 123", "123-1", "11111");
+        when(addressBookRepository.findById(addressBookDto.getId()))
             .thenReturn(Optional.of(addressBook));
 
-        userService.updateAddressBook(changeAddressRequest);
+        userService.updateAddressBook(addressBookDto);
 
         assertThat(addressBook.getAddress().getAddressName())
-            .isEqualTo(changeAddressRequest.getAddressName());
+            .isEqualTo(addressBookDto.getAddressName());
         assertThat(addressBook.getAddress().getDetailedAddress())
-            .isEqualTo(changeAddressRequest.getDetailedAddress());
+            .isEqualTo(addressBookDto.getDetailedAddress());
         assertThat(addressBook.getAddress().getPostalCode())
-            .isEqualTo(changeAddressRequest.getPostalCode());
+            .isEqualTo(addressBookDto.getPostalCode());
         assertThat(addressBook.getAddress().getRoadNameAddress())
-            .isEqualTo(changeAddressRequest.getRoadNameAddress());
+            .isEqualTo(addressBookDto.getRoadNameAddress());
 
         verify(addressBookRepository, atLeastOnce()).findById(any());
     }

--- a/src/test/java/com/flab/shoeauction/service/UserServiceTest.java
+++ b/src/test/java/com/flab/shoeauction/service/UserServiceTest.java
@@ -90,14 +90,14 @@ class UserServiceTest {
     @Test
     @DisplayName("비밀번호 찾기 성공 - 전달받은 객체(이메일)가 회원이라면 비밀번호 변경에 성공한다.")
     public void updatePassword() {
-        ChangePasswordRequest changePasswordRequest = of("test123.test.com", "test12345");
+        ChangePasswordRequest changePasswordRequest = of("test123.test.com", "test12345",null);
         User user = createUser().toEntity();
 
         when(userRepository.findByEmail(changePasswordRequest.getEmail())).thenReturn(Optional.of(user));
 
-        userService.updatePassword(changePasswordRequest);
+        userService.updatePasswordByForget(changePasswordRequest);
 
-        assertThat(user.getPassword()).isEqualTo(changePasswordRequest.getPassword());
+        assertThat(user.getPassword()).isEqualTo(changePasswordRequest.getPasswordAfter());
 
         verify(userRepository, atLeastOnce()).findByEmail(changePasswordRequest.getEmail());
     }


### PR DESCRIPTION
1. 판매 대금 환급 계좌 설정
2. 비밀번호 변경
 - 이전 비밀번호와 일치한 경우에만 비밀번호 변경 가능
3. 닉네임 변경
 - 닉네임 중복검사
 - 닉네임은 7일에 한번씩만 변경 가능하도록 설정
4. 주소록 관리
 -  List 컬렉션으로 주소록 관리
 - 주소록 추가, 수정, 삭제, 조회