### PR TITLE
[#31] feat : userLevel 추가 및 관련 로직 수정

### DIFF
--- a/src/main/java/com/flab/shoeauction/common/annotation/LoginCheck.java
+++ b/src/main/java/com/flab/shoeauction/common/annotation/LoginCheck.java
@@ -3,6 +3,7 @@ package com.flab.shoeauction.common.annotation;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import com.flab.shoeauction.domain.users.common.UserLevel;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -16,9 +17,5 @@ import java.lang.annotation.Target;
 @Target(METHOD)
 public @interface LoginCheck {
 
-    enum EmailAuthStatus {
-        UNAUTH, AUTH
-    }
-
-    EmailAuthStatus authority() default EmailAuthStatus.UNAUTH;
+    UserLevel authority() default UserLevel.UNAUTH;
 }

--- a/src/main/java/com/flab/shoeauction/common/interceptor/LoginCheckInterceptor.java
+++ b/src/main/java/com/flab/shoeauction/common/interceptor/LoginCheckInterceptor.java
@@ -2,7 +2,8 @@
 package com.flab.shoeauction.common.interceptor;
 
 import com.flab.shoeauction.common.annotation.LoginCheck;
-import com.flab.shoeauction.common.annotation.LoginCheck.EmailAuthStatus;
+import com.flab.shoeauction.domain.users.common.UserLevel;
+import com.flab.shoeauction.exception.user.NotAuthorizedException;
 import com.flab.shoeauction.exception.user.UnauthenticatedUserException;
 import com.flab.shoeauction.service.SessionLoginService;
 import javax.inject.Inject;
@@ -32,12 +33,10 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
         Object handler)
         throws Exception {
 
+        // test 환경에서는 인터셉트가 동작하지 않도록 설정
         String[] activeProfiles = environment.getActiveProfiles();
-
-        for(String profile : activeProfiles) {
-            if(profile.equals("test")) {
-                return true;
-            }
+        if (activeProfiles[0].equals("test")) {
+            return true;
         }
 
         if (handler instanceof HandlerMethod) {
@@ -52,14 +51,39 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
                 throw new UnauthenticatedUserException("로그인 후 이용 가능합니다.");
             }
 
-            EmailAuthStatus authStatus = loginCheck.authority();
-            if (authStatus == EmailAuthStatus.AUTH) {
-                if (!sessionLoginService.isEmailAuth()) {
-                    throw new UnauthenticatedUserException("이메일 인증 후 이용 가능합니다.");
-                }
+            UserLevel auth = loginCheck.authority();
 
+            switch (auth) {
+                case ADMIN:
+                    adminUserLevel();
+                    break;
+
+                case AUTH:
+                    authUserLevel();
+                    break;
             }
         }
         return true;
+    }
+
+    /**
+     * 현재 USER의 권한(UserLevel)이 AUTH인지 확인한다. 해당 리소스는 ADMIN과 AUTH만 접근 가능하다. 따라서 UNAUTH인 경우에만 제한한다.
+     */
+    private void authUserLevel() {
+        UserLevel auth = sessionLoginService.getUserLevel();
+        if (auth == UserLevel.UNAUTH) {
+            throw new NotAuthorizedException("해당 리소스에 대한 접근 권한이 존재하지 않습니다.");
+
+        }
+    }
+
+    /**
+     * 현재 USER의 권한(UserLevel)이 ADMIN인지 확인한다. ADMIN이 아니라면 해당 요청을 수행할 수 없다.
+     */
+    private void adminUserLevel() {
+        UserLevel auth = sessionLoginService.getUserLevel();
+        if (auth != UserLevel.ADMIN) {
+            throw new NotAuthorizedException("해당 리소스에 대한 접근 권한이 존재하지 않습니다.");
+        }
     }
 }

--- a/src/main/java/com/flab/shoeauction/common/interceptor/LoginCheckInterceptor.java
+++ b/src/main/java/com/flab/shoeauction/common/interceptor/LoginCheckInterceptor.java
@@ -35,7 +35,7 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
 
         // test 환경에서는 인터셉트가 동작하지 않도록 설정
         String[] activeProfiles = environment.getActiveProfiles();
-        if (activeProfiles[0].equals("test")) {
+        if ("test".equals(activeProfiles[0])) {
             return true;
         }
 
@@ -52,6 +52,7 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
             }
 
             UserLevel auth = loginCheck.authority();
+
 
             switch (auth) {
                 case ADMIN:

--- a/src/main/java/com/flab/shoeauction/common/utils/constants/ResponseConstants.java
+++ b/src/main/java/com/flab/shoeauction/common/utils/constants/ResponseConstants.java
@@ -1,4 +1,4 @@
-package com.flab.shoeauction.common.utils.response;
+package com.flab.shoeauction.common.utils.constants;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -53,4 +53,9 @@ public class ResponseConstants {
     public static final ResponseEntity<String> TOKEN_EXPIRED =
         new ResponseEntity<>("인증 토큰이 만료되었습니다. 마이페이지에서 인증 토큰 재전송 버튼을 클릭해 주세요!",
             HttpStatus.UNAUTHORIZED);
+
+    public static final ResponseEntity<String> NOT_AUTHORIZED =
+        new ResponseEntity<>("해당 리소스에 대한 접근 권한이 없습니다.",
+            HttpStatus.FORBIDDEN);
+
 }

--- a/src/main/java/com/flab/shoeauction/common/utils/constants/UserConstants.java
+++ b/src/main/java/com/flab/shoeauction/common/utils/constants/UserConstants.java
@@ -2,5 +2,5 @@ package com.flab.shoeauction.common.utils.constants;
 
 public class UserConstants {
     public static final String USER_ID = "email";
-    public static final String AUTH = "auth";
+    public static final String AUTH_STATUS = "auth";
 }

--- a/src/main/java/com/flab/shoeauction/controller/BrandApiController.java
+++ b/src/main/java/com/flab/shoeauction/controller/BrandApiController.java
@@ -1,7 +1,7 @@
 package com.flab.shoeauction.controller;
 
-import static com.flab.shoeauction.common.utils.response.ResponseConstants.CREATED;
-import static com.flab.shoeauction.common.utils.response.ResponseConstants.OK;
+import static com.flab.shoeauction.common.utils.constants.ResponseConstants.CREATED;
+import static com.flab.shoeauction.common.utils.constants.ResponseConstants.OK;
 
 import com.flab.shoeauction.controller.dto.BrandDto.BrandInfo;
 import com.flab.shoeauction.controller.dto.BrandDto.SaveRequest;

--- a/src/main/java/com/flab/shoeauction/controller/ProductApiController.java
+++ b/src/main/java/com/flab/shoeauction/controller/ProductApiController.java
@@ -1,7 +1,7 @@
 package com.flab.shoeauction.controller;
 
-import static com.flab.shoeauction.common.utils.response.ResponseConstants.CREATED;
-import static com.flab.shoeauction.common.utils.response.ResponseConstants.OK;
+import static com.flab.shoeauction.common.utils.constants.ResponseConstants.CREATED;
+import static com.flab.shoeauction.common.utils.constants.ResponseConstants.OK;
 
 import com.flab.shoeauction.controller.dto.ProductDto.ProductInfoResponse;
 import com.flab.shoeauction.controller.dto.ProductDto.SaveRequest;

--- a/src/main/java/com/flab/shoeauction/controller/UserApiController.java
+++ b/src/main/java/com/flab/shoeauction/controller/UserApiController.java
@@ -1,7 +1,7 @@
 package com.flab.shoeauction.controller;
 
-import static com.flab.shoeauction.common.utils.response.ResponseConstants.CREATED;
-import static com.flab.shoeauction.common.utils.response.ResponseConstants.OK;
+import static com.flab.shoeauction.common.utils.constants.ResponseConstants.CREATED;
+import static com.flab.shoeauction.common.utils.constants.ResponseConstants.OK;
 
 import com.flab.shoeauction.common.annotation.CurrentUser;
 import com.flab.shoeauction.common.annotation.LoginCheck;
@@ -17,6 +17,7 @@ import com.flab.shoeauction.controller.dto.UserDto.UserInfoDto;
 import com.flab.shoeauction.domain.addressBook.Address;
 import com.flab.shoeauction.domain.addressBook.AddressBook;
 import com.flab.shoeauction.domain.users.common.Account;
+import com.flab.shoeauction.domain.users.common.UserLevel;
 import com.flab.shoeauction.service.SessionLoginService;
 import com.flab.shoeauction.service.UserService;
 import com.flab.shoeauction.service.certification.EmailCertificationService;
@@ -97,7 +98,6 @@ public class UserApiController {
         sessionLoginService.logout();
     }
 
-    @LoginCheck
     @GetMapping("/my-infos")
     public ResponseEntity<UserInfoDto> myPage(@CurrentUser String email) {
         UserInfoDto loginUser = sessionLoginService.getCurrentUser(email);
@@ -108,6 +108,7 @@ public class UserApiController {
      * 비밀번호 찾기 : 이메일 입력시, 존재하는 이메일이면 휴대폰인증과 이메일인증 중 택1 하도록 구현 휴대폰 인증 선택시 : sendSms / SmsVerification
      * 핸들러 이메일 인증 선택시 : sendEmail / emailVerification 핸들러
      */
+
     @GetMapping("/find/{email}")
     public ResponseEntity<FindUserResponse> findUser(@PathVariable String email) {
         FindUserResponse findUserResponse = userService.getUserResource(email);

--- a/src/main/java/com/flab/shoeauction/controller/dto/UserDto.java
+++ b/src/main/java/com/flab/shoeauction/controller/dto/UserDto.java
@@ -124,16 +124,18 @@ public class UserDto {
         private List<AddressBook> addressBooks;
         private Account account;
         private UserLevel userLevel;
+        private boolean isBan;
 
         @Builder
         public UserInfoDto(String email, String nickname, String phone,
-            List<AddressBook> addressBooks, Account account, UserLevel userLevel) {
+            List<AddressBook> addressBooks, Account account, UserLevel userLevel, boolean isBan) {
             this.email = email;
             this.nickname = nickname;
             this.phone = phone;
             this.addressBooks = addressBooks;
             this.account = account;
             this.userLevel = userLevel;
+            this.isBan = isBan;
         }
 
     }

--- a/src/main/java/com/flab/shoeauction/controller/dto/UserDto.java
+++ b/src/main/java/com/flab/shoeauction/controller/dto/UserDto.java
@@ -61,7 +61,7 @@ public class UserDto {
                 .password(this.password)
                 .nicknameModifiedDate(LocalDateTime.now())
                 .phone(this.phone)
-                .userLevel(UserLevel.USER)
+                .userLevel(UserLevel.UNAUTH)
                 .build();
         }
     }
@@ -123,17 +123,17 @@ public class UserDto {
         private String phone;
         private List<AddressBook> addressBooks;
         private Account account;
-        private boolean emailVerified;
+        private UserLevel userLevel;
 
         @Builder
         public UserInfoDto(String email, String nickname, String phone,
-            List<AddressBook> addressBooks, Account account, Boolean emailVerified) {
+            List<AddressBook> addressBooks, Account account, UserLevel userLevel) {
             this.email = email;
             this.nickname = nickname;
             this.phone = phone;
             this.addressBooks = addressBooks;
             this.account = account;
-            this.emailVerified = emailVerified;
+            this.userLevel = userLevel;
         }
 
     }

--- a/src/main/java/com/flab/shoeauction/domain/users/common/UserLevel.java
+++ b/src/main/java/com/flab/shoeauction/domain/users/common/UserLevel.java
@@ -1,12 +1,10 @@
 package com.flab.shoeauction.domain.users.common;
 
 /**
- * UNAUTH : 회원가입 후 이메일 인증을 완료하지 않은 사용자 (일부 기능 제한)
- * AUTH : 회원 가입 후 이메일 인증을 완료한 사용자(관리자 기능 외 모든 기능 이용 가능)
- * BAN : 관리자에 의해 정지된 사용자(서비스 이용 불가능)
- * ADMIN : 관리자
+ * UNAUTH : 회원가입 후 이메일 인증을 완료하지 않은 사용자 (일부 기능 제한) AUTH : 회원 가입 후 이메일 인증을 완료한 사용자(관리자 기능 외 모든 기능 이용
+ * 가능) BAN : 관리자에 의해 정지된 사용자(서비스 이용 불가능) ADMIN : 관리자
  */
 
 public enum UserLevel {
-    UNAUTH, AUTH, BAN, ADMIN
+    UNAUTH, AUTH, ADMIN
 }

--- a/src/main/java/com/flab/shoeauction/domain/users/common/UserLevel.java
+++ b/src/main/java/com/flab/shoeauction/domain/users/common/UserLevel.java
@@ -1,5 +1,12 @@
 package com.flab.shoeauction.domain.users.common;
 
+/**
+ * UNAUTH : 회원가입 후 이메일 인증을 완료하지 않은 사용자 (일부 기능 제한)
+ * AUTH : 회원 가입 후 이메일 인증을 완료한 사용자(관리자 기능 외 모든 기능 이용 가능)
+ * BAN : 관리자에 의해 정지된 사용자(서비스 이용 불가능)
+ * ADMIN : 관리자
+ */
+
 public enum UserLevel {
-    USER, ADMIN
+    UNAUTH, AUTH, BAN, ADMIN
 }

--- a/src/main/java/com/flab/shoeauction/domain/users/user/User.java
+++ b/src/main/java/com/flab/shoeauction/domain/users/user/User.java
@@ -33,8 +33,6 @@ public class User extends UserBase {
 
     private String phone;
 
-    private boolean emailVerified;
-
     @Embedded
     private Account account;
 
@@ -50,7 +48,7 @@ public class User extends UserBase {
             .nickname(this.getNickname())
             .phone(this.getPhone())
             .account(this.getAccount())
-            .emailVerified(this.getEmailVerified())
+            .userLevel(this.userLevel)
             .build();
     }
 
@@ -87,12 +85,8 @@ public class User extends UserBase {
         return !(this.nicknameModifiedDate.isBefore(LocalDateTime.now().minusDays(7)));
     }
 
-    public void updateEmailVerified() {
-        this.emailVerified = true;
-    }
-
-    public boolean getEmailVerified() {
-        return this.emailVerified;
+    public void updateUserLevel() {
+        this.userLevel = UserLevel.AUTH;
     }
 
     @Builder

--- a/src/main/java/com/flab/shoeauction/domain/users/user/User.java
+++ b/src/main/java/com/flab/shoeauction/domain/users/user/User.java
@@ -38,6 +38,8 @@ public class User extends UserBase {
 
     private LocalDateTime nicknameModifiedDate;
 
+    private boolean isBan;
+
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "USER_ID")
     private List<AddressBook> addressesBook = new ArrayList<>();
@@ -49,6 +51,7 @@ public class User extends UserBase {
             .phone(this.getPhone())
             .account(this.getAccount())
             .userLevel(this.userLevel)
+            .isBan(this.isBan)
             .build();
     }
 

--- a/src/main/java/com/flab/shoeauction/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flab/shoeauction/exception/GlobalExceptionHandler.java
@@ -1,17 +1,18 @@
 package com.flab.shoeauction.exception;
 
-import static com.flab.shoeauction.common.utils.response.ResponseConstants.BAD_REQUEST;
-import static com.flab.shoeauction.common.utils.response.ResponseConstants.BRAND_NOT_FOUND;
-import static com.flab.shoeauction.common.utils.response.ResponseConstants.DUPLICATION_BRAND_NAME;
-import static com.flab.shoeauction.common.utils.response.ResponseConstants.DUPLICATION_EMAIL;
-import static com.flab.shoeauction.common.utils.response.ResponseConstants.DUPLICATION_MODEL_NUMBER;
-import static com.flab.shoeauction.common.utils.response.ResponseConstants.DUPLICATION_NICKNAME;
-import static com.flab.shoeauction.common.utils.response.ResponseConstants.PRODUCT_NOT_FOUND;
-import static com.flab.shoeauction.common.utils.response.ResponseConstants.FAIL_TO_CHANGE_NICKNAME;
-import static com.flab.shoeauction.common.utils.response.ResponseConstants.TOKEN_EXPIRED;
-import static com.flab.shoeauction.common.utils.response.ResponseConstants.UNAUTHORIZED_USER;
-import static com.flab.shoeauction.common.utils.response.ResponseConstants.USER_NOT_FOUND;
-import static com.flab.shoeauction.common.utils.response.ResponseConstants.WRONG_PASSWORD;
+import static com.flab.shoeauction.common.utils.constants.ResponseConstants.BAD_REQUEST;
+import static com.flab.shoeauction.common.utils.constants.ResponseConstants.BRAND_NOT_FOUND;
+import static com.flab.shoeauction.common.utils.constants.ResponseConstants.DUPLICATION_BRAND_NAME;
+import static com.flab.shoeauction.common.utils.constants.ResponseConstants.DUPLICATION_EMAIL;
+import static com.flab.shoeauction.common.utils.constants.ResponseConstants.DUPLICATION_MODEL_NUMBER;
+import static com.flab.shoeauction.common.utils.constants.ResponseConstants.DUPLICATION_NICKNAME;
+import static com.flab.shoeauction.common.utils.constants.ResponseConstants.FAIL_TO_CHANGE_NICKNAME;
+import static com.flab.shoeauction.common.utils.constants.ResponseConstants.NOT_AUTHORIZED;
+import static com.flab.shoeauction.common.utils.constants.ResponseConstants.PRODUCT_NOT_FOUND;
+import static com.flab.shoeauction.common.utils.constants.ResponseConstants.TOKEN_EXPIRED;
+import static com.flab.shoeauction.common.utils.constants.ResponseConstants.UNAUTHORIZED_USER;
+import static com.flab.shoeauction.common.utils.constants.ResponseConstants.USER_NOT_FOUND;
+import static com.flab.shoeauction.common.utils.constants.ResponseConstants.WRONG_PASSWORD;
 
 import com.flab.shoeauction.exception.brand.BrandNotFoundException;
 import com.flab.shoeauction.exception.brand.DuplicateBrandNameException;
@@ -20,6 +21,7 @@ import com.flab.shoeauction.exception.product.ProductNotFoundException;
 import com.flab.shoeauction.exception.user.AuthenticationNumberMismatchException;
 import com.flab.shoeauction.exception.user.DuplicateEmailException;
 import com.flab.shoeauction.exception.user.DuplicateNicknameException;
+import com.flab.shoeauction.exception.user.NotAuthorizedException;
 import com.flab.shoeauction.exception.user.TokenExpiredException;
 import com.flab.shoeauction.exception.user.UnableToChangeNicknameException;
 import com.flab.shoeauction.exception.user.UnauthenticatedUserException;
@@ -131,5 +133,13 @@ public class GlobalExceptionHandler {
         log.debug("Token Expired :: {} , detection time={}", request.getDescription(false),
             LocalDateTime.now(), ex);
         return TOKEN_EXPIRED;
+    }
+
+    @ExceptionHandler(NotAuthorizedException.class)
+    public final ResponseEntity handleNotAuthorizedException(NotAuthorizedException ex,
+        WebRequest webRequest) {
+        log.debug("Not Authorized :: {}, detection time ={}", webRequest.getDescription(false),
+            LocalDateTime.now(), ex);
+        return NOT_AUTHORIZED;
     }
 }

--- a/src/main/java/com/flab/shoeauction/exception/user/NotAuthorizedException.java
+++ b/src/main/java/com/flab/shoeauction/exception/user/NotAuthorizedException.java
@@ -1,0 +1,8 @@
+package com.flab.shoeauction.exception.user;
+
+public class NotAuthorizedException extends RuntimeException {
+
+    public NotAuthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/flab/shoeauction/service/SessionLoginService.java
+++ b/src/main/java/com/flab/shoeauction/service/SessionLoginService.java
@@ -49,7 +49,7 @@ public class SessionLoginService {
     }
 
     private void banCheck(User user) {
-        if(user.getUserLevel() == UserLevel.BAN) {
+        if(user.isBan()) {
             throw new NotAuthorizedException("관리자에 의해 이용이 정지된 사용자 입니다.");
         }
     }

--- a/src/main/java/com/flab/shoeauction/service/SessionLoginService.java
+++ b/src/main/java/com/flab/shoeauction/service/SessionLoginService.java
@@ -1,12 +1,14 @@
 package com.flab.shoeauction.service;
 
-import static com.flab.shoeauction.common.utils.constants.UserConstants.AUTH;
+import static com.flab.shoeauction.common.utils.constants.UserConstants.AUTH_STATUS;
 import static com.flab.shoeauction.common.utils.constants.UserConstants.USER_ID;
 
 import com.flab.shoeauction.controller.dto.UserDto.LoginRequest;
 import com.flab.shoeauction.controller.dto.UserDto.UserInfoDto;
+import com.flab.shoeauction.domain.users.common.UserLevel;
 import com.flab.shoeauction.domain.users.user.User;
 import com.flab.shoeauction.domain.users.user.UserRepository;
+import com.flab.shoeauction.exception.user.NotAuthorizedException;
 import com.flab.shoeauction.exception.user.UserNotFoundException;
 import com.flab.shoeauction.service.encrytion.EncryptionService;
 import javax.servlet.http.HttpSession;
@@ -33,28 +35,37 @@ public class SessionLoginService {
     public void login(LoginRequest loginRequest) {
         existByEmailAndPassword(loginRequest);
         String email = loginRequest.getEmail();
+        setUserLevel(email);
         session.setAttribute(USER_ID, email);
-        setAuthSession(email);
     }
 
-    public void setAuthSession(String email) {
+    public void setUserLevel(String email) {
         User user = userRepository.findByEmail(email)
             .orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자 입니다."));
-        session.setAttribute(AUTH, user.getEmailVerified());
+
+        banCheck(user);
+
+        session.setAttribute(AUTH_STATUS, user.getUserLevel());
+    }
+
+    private void banCheck(User user) {
+        if(user.getUserLevel() == UserLevel.BAN) {
+            throw new NotAuthorizedException("관리자에 의해 이용이 정지된 사용자 입니다.");
+        }
+    }
+
+    public UserLevel getUserLevel() {
+        return (UserLevel) session.getAttribute(AUTH_STATUS);
     }
 
     public void logout() {
         session.removeAttribute(USER_ID);
-        session.removeAttribute(AUTH);
     }
 
     public String getLoginUser() {
         return (String) session.getAttribute(USER_ID);
     }
 
-    public boolean isEmailAuth() {
-        return (Boolean) session.getAttribute(AUTH);
-    }
 
     public UserInfoDto getCurrentUser(String email) {
         return userRepository.findByEmail(email)

--- a/src/main/java/com/flab/shoeauction/service/UserService.java
+++ b/src/main/java/com/flab/shoeauction/service/UserService.java
@@ -155,6 +155,6 @@ public class UserService {
 
         User user = userRepository.findByEmail(email)
             .orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자 입니다."));
-        user.updateEmailVerified();
+        user.updateUserLevel();
     }
 }

--- a/src/test/java/com/flab/shoeauction/controller/UserApiControllerTest.java
+++ b/src/test/java/com/flab/shoeauction/controller/UserApiControllerTest.java
@@ -36,6 +36,7 @@ import com.flab.shoeauction.controller.dto.UserDto.UserInfoDto;
 import com.flab.shoeauction.domain.addressBook.Address;
 import com.flab.shoeauction.domain.addressBook.AddressBook;
 import com.flab.shoeauction.domain.users.common.Account;
+import com.flab.shoeauction.domain.users.common.UserLevel;
 import com.flab.shoeauction.exception.user.AuthenticationNumberMismatchException;
 import com.flab.shoeauction.exception.user.DuplicateEmailException;
 import com.flab.shoeauction.exception.user.TokenExpiredException;
@@ -411,7 +412,8 @@ class UserApiControllerTest {
             .phone("01012345678")
             .account(new Account("카카오뱅크", "123456789", "정기혁"))
             .addressBooks(addressBooks)
-            .emailVerified(true).build();
+            .userLevel(UserLevel.UNAUTH)
+            .build();
 
         String email = "jungkh405@naver.com";
 
@@ -430,7 +432,7 @@ class UserApiControllerTest {
                         .description("회원 환급 계좌정보"),
                     subsectionWithPath("addressBooks").type(JsonFieldType.ARRAY)
                         .description("회원 주소록"),
-                    fieldWithPath("emailVerified").type(JsonFieldType.BOOLEAN)
+                    fieldWithPath("userLevel").type(JsonFieldType.STRING)
                         .description("이메일 인증 여부")
                 )));
     }


### PR DESCRIPTION
1. userLevel (UNAUTH, AUTH, BAN, ADMIN) 추가
2. userLevel 별 로그인 인터셉터 수정
3. ResponseConstants class ->  constants패키지로 이동
4. User 클래스에 인증 여부를 확인하는 필드 삭제 -> userLevel로 대체
5. 4번 수정에 따른 관련 테스트코드 수정

 #31 : UserLevel(권한) 구현 및 관련 로직 수정