### PR TITLE
[#54] feat : 위시리스트 도메인 설계

### DIFF
--- a/src/main/java/com/flab/shoeauction/domain/cart/Cart.java
+++ b/src/main/java/com/flab/shoeauction/domain/cart/Cart.java
@@ -1,0 +1,23 @@
+package com.flab.shoeauction.domain.cart;
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Cart {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @OneToMany(mappedBy = "cart")
+    private Set<CartProduct> wishList = new HashSet<>();
+}

--- a/src/main/java/com/flab/shoeauction/domain/cart/Cart.java
+++ b/src/main/java/com/flab/shoeauction/domain/cart/Cart.java
@@ -1,11 +1,13 @@
 package com.flab.shoeauction.domain.cart;
 
+import com.flab.shoeauction.domain.users.user.User;
 import java.util.HashSet;
 import java.util.Set;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -17,6 +19,9 @@ public class Cart {
     @Id
     @GeneratedValue
     private Long id;
+
+    @OneToOne(mappedBy = "user")
+    private User user;
 
     @OneToMany(mappedBy = "cart")
     private Set<CartProduct> wishList = new HashSet<>();

--- a/src/main/java/com/flab/shoeauction/domain/cart/CartProduct.java
+++ b/src/main/java/com/flab/shoeauction/domain/cart/CartProduct.java
@@ -1,0 +1,35 @@
+package com.flab.shoeauction.domain.cart;
+
+import com.flab.shoeauction.domain.product.Product;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * CART에는 여러 PRODUCT를 담을 수 있고, PRODUCT 또한 여러 CART에 포함될 수 있다. 따라서 ManyToMany를 형성한다.
+ * ManyToMany의 경우 정규화를 통해 1:N , N:1로 처리해야 한다.  따라서 중간테이블인 CartProduct라는 중간테이블을 생성해야 한다.
+ */
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CartProduct {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "CART_ID")
+    private Cart cart;
+
+    @ManyToOne
+    @JoinColumn(name = "PRODUCT_ID")
+    private Product product;
+
+}

--- a/src/main/java/com/flab/shoeauction/domain/users/user/User.java
+++ b/src/main/java/com/flab/shoeauction/domain/users/user/User.java
@@ -6,6 +6,7 @@ import com.flab.shoeauction.controller.dto.UserDto.UserDetailsResponse;
 import com.flab.shoeauction.controller.dto.UserDto.UserInfoDto;
 import com.flab.shoeauction.domain.addressBook.Address;
 import com.flab.shoeauction.domain.addressBook.AddressBook;
+import com.flab.shoeauction.domain.cart.Cart;
 import com.flab.shoeauction.domain.users.common.Account;
 import com.flab.shoeauction.domain.users.common.UserBase;
 import com.flab.shoeauction.domain.users.common.UserLevel;
@@ -17,8 +18,10 @@ import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -45,6 +48,13 @@ public class User extends UserBase {
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "USER_ID")
     private List<AddressBook> addressesBook = new ArrayList<>();
+
+    /**
+     * USER는 하나의 CART만 가질 수 있고, CART 또한 여러명의 유저가 함께 사용할 수 없다. 따라서 일대일 매핑으로 처리한다.
+     */
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "CART_ID")
+    private Cart cart;
 
     public UserInfoDto toUserInfoDto() {
         return UserInfoDto.builder()


### PR DESCRIPTION
이전에 PR했던(현재는 Close상태) 위시리스트(카트) 도메인 설계의 문제점을 개선한 PR입니다.
**기존방식의 문제점**
- CART와 PRODUCT를 `oneToMany` 로 매핑하게 되면 Product에 CART_ID 값이 종속되어 해당 상품을 CART에 담을때 마다 CART_ID 값이 변경됩니다. 따라서 A유저가 CART에 `ITEMA` 라는 PRODUCT를 담고, 이후 B 유저가 CART에 `ITEMA`를 담으면 카트를 불러왔을 때 A유저의 카트에는 `ITEMA`가 존재하지 않게 됩니다.

**개선 방식**
- CART와 PRODUCT를 ManyToMany 관계로 보고, 중간에 `CartProduct`라는 중간 테이블을 설계하여 각각 OneToMany, ManyToOne으로 설계하였습니다.