### PR TITLE
 JPA관련 성능 최적화

### DIFF
--- a/src/main/java/com/flab/shoeauction/controller/dto/TradeDto.java
+++ b/src/main/java/com/flab/shoeauction/controller/dto/TradeDto.java
@@ -52,7 +52,7 @@ public class TradeDto {
 
         private Long price;
         private double productSize;
-        private Long productId; // DTO로 받도록 리팩토링
+        private Long productId;
         private Long addressId;
 
         @Builder
@@ -62,6 +62,7 @@ public class TradeDto {
             this.productSize = productSize;
             this.price = price;
             this.addressId = addressId;
+
         }
 
         // 판매 입찰용
@@ -106,5 +107,4 @@ public class TradeDto {
             this.productId = productId;
         }
     }
-
 }

--- a/src/main/java/com/flab/shoeauction/domain/addressBook/Address.java
+++ b/src/main/java/com/flab/shoeauction/domain/addressBook/Address.java
@@ -10,9 +10,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/**
- * 도로명 주소,상세주소
- */
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/flab/shoeauction/domain/cart/Cart.java
+++ b/src/main/java/com/flab/shoeauction/domain/cart/Cart.java
@@ -18,7 +18,7 @@ public class Cart {
     @GeneratedValue
     private Long id;
 
-    @OneToMany(mappedBy = "cart")
+    @OneToMany(mappedBy = "cart", orphanRemoval = true)
     private Set<CartProduct> wishList = new HashSet<>();
 
     public void addCartProducts(CartProduct cartItem) {

--- a/src/main/java/com/flab/shoeauction/domain/product/Product.java
+++ b/src/main/java/com/flab/shoeauction/domain/product/Product.java
@@ -1,7 +1,7 @@
 package com.flab.shoeauction.domain.product;
 
-import com.flab.shoeauction.controller.dto.ProductDto.ProductInfoResponse;
 import com.flab.shoeauction.controller.dto.ProductDto.ProductInfoByTrade;
+import com.flab.shoeauction.controller.dto.ProductDto.ProductInfoResponse;
 import com.flab.shoeauction.controller.dto.ProductDto.SaveRequest;
 import com.flab.shoeauction.controller.dto.TradeDto.TradeBidResponse;
 import com.flab.shoeauction.domain.BaseTimeEntity;
@@ -15,14 +15,17 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.NamedEntityGraph;
 import javax.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -39,6 +42,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
+@NamedEntityGraph()
 public class Product extends BaseTimeEntity {
 
     @Id
@@ -79,16 +83,11 @@ public class Product extends BaseTimeEntity {
 
     private String resizedImagePath;
 
-    /*
-     * 상품 조회 등의 Product를 사용 하는 비즈니스 로직은 대부분 Brand를 함께 사용한다.
-     * 그렇기에 어차피 함께 사용할 Brand에 지연로딩을 설정하는 것은 조회 효율만 낮출 뿐이다.
-     * 따라서 FetchType의 디폴트인 EAGER(즉시로딩)을 사용하여 조인쿼리로 조회하는 편이 좋다.
-     */
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "BRAND_ID")
     private Brand brand;
 
-    @OneToMany(mappedBy = "product", orphanRemoval = true)
+    @OneToMany(mappedBy = "product", orphanRemoval = true, cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Trade> trades = new ArrayList<>();
 
     public ProductInfoResponse toProductInfoResponse() {

--- a/src/main/java/com/flab/shoeauction/domain/product/ProductRepository.java
+++ b/src/main/java/com/flab/shoeauction/domain/product/ProductRepository.java
@@ -1,9 +1,16 @@
 package com.flab.shoeauction.domain.product;
 
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
     boolean existsByModelNumber(String modelNumber);
+
+    @Override
+    @EntityGraph(attributePaths = {"trades", "brand"})
+    Optional<Product> findById(Long id);
+
 }

--- a/src/main/java/com/flab/shoeauction/domain/users/user/User.java
+++ b/src/main/java/com/flab/shoeauction/domain/users/user/User.java
@@ -16,7 +16,6 @@ import com.flab.shoeauction.domain.users.common.UserLevel;
 import com.flab.shoeauction.domain.users.common.UserStatus;
 import com.flab.shoeauction.exception.user.UnableToChangeNicknameException;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.persistence.Embedded;
@@ -54,7 +53,7 @@ public class User extends UserBase {
     /**
      * USER는 하나의 CART만 가질 수 있고, CART 또한 여러명의 유저가 함께 사용할 수 없다. 따라서 일대일 매핑으로 처리한다.
      */
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, orphanRemoval = true)
     @JoinColumn(name = "CART_ID")
     private Cart cart;
 

--- a/src/main/java/com/flab/shoeauction/domain/users/user/User.java
+++ b/src/main/java/com/flab/shoeauction/domain/users/user/User.java
@@ -16,6 +16,7 @@ import com.flab.shoeauction.domain.users.common.UserLevel;
 import com.flab.shoeauction.domain.users.common.UserStatus;
 import com.flab.shoeauction.exception.user.UnableToChangeNicknameException;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.persistence.Embedded;
@@ -46,7 +47,7 @@ public class User extends UserBase {
 
     private UserStatus userStatus;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY, orphanRemoval = true)
     @JoinColumn(name = "ADDRESSBOOK_ID")
     private AddressBook addressBook;
 

--- a/src/main/java/com/flab/shoeauction/domain/users/user/UserRepository.java
+++ b/src/main/java/com/flab/shoeauction/domain/users/user/UserRepository.java
@@ -2,9 +2,13 @@ package com.flab.shoeauction.domain.users.user;
 
 import com.flab.shoeauction.domain.users.admin.AdminRepository;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long>, AdminRepository {
+
+    @EntityGraph(attributePaths = {"addressBook"})
+    Optional<User> findByEmail(String email);
 
     boolean existsByEmail(String email);
 
@@ -12,10 +16,6 @@ public interface UserRepository extends JpaRepository<User, Long>, AdminReposito
 
     boolean existsByEmailAndPassword(String email, String password);
 
-    Optional<User> findByEmail(String email);
-
     void deleteByEmail(String email);
-
-
 
 }


### PR DESCRIPTION
1. Fetch 전략을 EAGER로 사용할 경우 예상치 못한 쿼리가 실행되는 문제가 발생합니다. 따라서 Product를 조회할때 항상 brand를 함께 사용하더라도 Lazy전략으로 설정 후 발생하는 N+1 문제를 Fetch join 또는 @EntityGraph를 통해 해결하는 방향으로 수정하였습니다.
2. 그 외 N+1문제가 발생하는 부분을 찾아서 수정하였습니다.
3. `orphanRemoval = true` 옵션을 추가해 부모 객체가 삭제되었을 경우 자식 객체도 함께 삭제되도록 설정하였습니다.

issue number: #85