### PR TITLE
상품 검수 및 결과에 따른 처리 기능 구현

### DIFF
--- a/src/main/java/com/flab/shoeauction/controller/TradeApiController.java
+++ b/src/main/java/com/flab/shoeauction/controller/TradeApiController.java
@@ -82,4 +82,23 @@ public class TradeApiController {
     public void confirmWarehousing(@PathVariable Long id) {
         tradeService.confirmWarehousing(id);
     }
+
+    @LoginCheck(authority = UserLevel.ADMIN)
+    @PatchMapping("{id}/inspection-successful")
+    public void inspectionSuccessful(@PathVariable Long id) {
+        tradeService.inspectionSuccessful(id);
+    }
+
+    @LoginCheck(authority = UserLevel.ADMIN)
+    @PatchMapping("{id}/inspection-failed")
+    public void inspectionFailed(@PathVariable Long id, @RequestBody String reason) {
+        tradeService.inspectionFailed(id, reason);
+    }
+
+    @LoginCheck(authority = UserLevel.ADMIN)
+    @PatchMapping("{id}/return-tracking-number")
+    public void updateReturnTrackingNumber(@PathVariable Long id,
+        @RequestBody String trackingNumber) {
+        tradeService.updateReturnTrackingNumber(id, trackingNumber);
+    }
 }

--- a/src/main/java/com/flab/shoeauction/domain/trade/Trade.java
+++ b/src/main/java/com/flab/shoeauction/domain/trade/Trade.java
@@ -139,4 +139,10 @@ public class Trade extends BaseTimeEntity {
     public void recoverBuyerPoints(Long price) {
         buyer.chargingPoint(price);
     }
+
+    public void cancelBecauseOfInspection(String reason){
+        this.cancelReason = reason;
+        this.status = TradeStatus.CANCEL;
+        buyer.chargingPoint(price);
+    }
 }

--- a/src/main/java/com/flab/shoeauction/service/TradeService.java
+++ b/src/main/java/com/flab/shoeauction/service/TradeService.java
@@ -1,6 +1,7 @@
 package com.flab.shoeauction.service;
 
 import static com.flab.shoeauction.domain.trade.TradeStatus.PRE_INSPECTION;
+import static com.flab.shoeauction.domain.trade.TradeStatus.PRE_SHIPMENT;
 import static com.flab.shoeauction.domain.trade.TradeStatus.PRE_WAREHOUSING;
 
 import com.flab.shoeauction.controller.dto.ProductDto.ProductInfoByTrade;
@@ -151,5 +152,26 @@ public class TradeService {
         Trade trade = tradeRepository.findById(tradeId).orElseThrow();
 
         trade.updateStatus(PRE_INSPECTION);
+    }
+
+    @Transactional
+    public void inspectionSuccessful(Long tradeId) {
+        Trade trade = tradeRepository.findById(tradeId).orElseThrow();
+
+        trade.updateStatus(PRE_SHIPMENT);
+    }
+
+    @Transactional
+    public void inspectionFailed(Long tradeId, String reason) {
+        Trade trade = tradeRepository.findById(tradeId).orElseThrow();
+
+        trade.cancelBecauseOfInspection(reason);
+    }
+
+    @Transactional
+    public void updateReturnTrackingNumber(Long tradeId, String trackingNumber) {
+        Trade trade = tradeRepository.findById(tradeId).orElseThrow();
+
+        trade.updateReturnTrackingNumber(trackingNumber);
     }
 }

--- a/src/test/java/com/flab/shoeauction/service/TradeServiceTest.java
+++ b/src/test/java/com/flab/shoeauction/service/TradeServiceTest.java
@@ -1,7 +1,9 @@
 package com.flab.shoeauction.service;
 
+import static com.flab.shoeauction.domain.trade.TradeStatus.CANCEL;
 import static com.flab.shoeauction.domain.trade.TradeStatus.PRE_CONCLUSION;
 import static com.flab.shoeauction.domain.trade.TradeStatus.PRE_INSPECTION;
+import static com.flab.shoeauction.domain.trade.TradeStatus.PRE_SHIPMENT;
 import static com.flab.shoeauction.domain.trade.TradeStatus.PRE_WAREHOUSING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -331,7 +333,6 @@ class TradeServiceTest {
     }
 
 
-
     @DisplayName("물품 즉시 구매에 성공한다.")
     @Test
     public void immediatePurchase() {
@@ -365,7 +366,6 @@ class TradeServiceTest {
         when(addressRepository.findById(requestDto.getAddressId()))
             .thenReturn(Optional.of(address));
         tradeService.immediatePurchase(email, requestDto);
-
 
         assertThat(saleTrade.getStatus()).isEqualTo(TradeStatus.PRE_SELLER_SHIPMENT);
         assertThat(saleTrade.getBuyer().getId()).isEqualTo(user.getId());
@@ -521,5 +521,47 @@ class TradeServiceTest {
         tradeService.confirmWarehousing(tradeId);
 
         assertThat(trade.getStatus()).isEqualTo(PRE_INSPECTION);
+    }
+
+    @DisplayName("특정 상품의 검수 결과를 적합으로 처리한다.")
+    @Test
+    public void inspectionSuccessful() {
+        Trade trade = createConcludedBuyersTrade();
+        Long tradeId = trade.getId();
+        given(tradeRepository.findById(tradeId)).willReturn(Optional.of(trade));
+
+        tradeService.inspectionSuccessful(tradeId);
+
+        assertThat(trade.getStatus()).isEqualTo(PRE_SHIPMENT);
+    }
+
+    @DisplayName("특정 상품의 검수 결과를 부적합으로 처리한다.")
+    @Test
+    public void inspectionFailed() {
+        Trade trade = createConcludedBuyersTrade();
+        Long tradeId = trade.getId();
+        User buyer = trade.getBuyer();
+        Long buyersPoint = buyer.getPoint();
+        String reason = "가죽 스크래치 및 박음질 불량";
+        given(tradeRepository.findById(tradeId)).willReturn(Optional.of(trade));
+
+        tradeService.inspectionFailed(tradeId, reason);
+
+        assertThat(trade.getStatus()).isEqualTo(CANCEL);
+        assertThat(trade.getCancelReason()).isEqualTo(reason);
+        assertThat(buyer.getPoint()).isEqualTo(buyersPoint + trade.getPrice());
+    }
+
+    @DisplayName("부적합 처리된 상품을 반송하고 반송 운송장 번호를 입력한다.")
+    @Test
+    public void updateReturnTrackingNumber() {
+        Trade trade = createConcludedBuyersTrade();
+        Long tradeId = trade.getId();
+        String trackingNumber = "987654321";
+        given(tradeRepository.findById(tradeId)).willReturn(Optional.of(trade));
+
+        tradeService.updateReturnTrackingNumber(tradeId, trackingNumber);
+
+        assertThat(trade.getReturnTrackingNumber()).isEqualTo(trackingNumber);
     }
 }


### PR DESCRIPTION
- 회사 측에서 상품 입고를 확인한 후 TradeStatus가 `PRE_INSPECTION` 상태로 넘어갔을 경우 검수 시작
- 검수 적합 판정 시 TradeStatus를 `PRE_SHIPMENT`로 변경
- 검수 부적합 판정 시 TradeStatus를 `CANCEL`로 변경 후 검수 부적합 사유 입력, 구매 포인트 환급
- 검수 부적합 판정이 발생한 거래의 상품을 반송 후 반송 운소장 번호 입력