### PR TITLE
검수가 완료된 상품 발송 및 구매 확정 구현

### DIFF
--- a/src/main/java/com/flab/shoeauction/controller/TradeApiController.java
+++ b/src/main/java/com/flab/shoeauction/controller/TradeApiController.java
@@ -101,4 +101,17 @@ public class TradeApiController {
         @RequestBody String trackingNumber) {
         tradeService.updateReturnTrackingNumber(id, trackingNumber);
     }
+
+    @LoginCheck(authority = UserLevel.ADMIN)
+    @PatchMapping("{id}/forwarding-Tracking-Number")
+    public void updateForwardingTrackingNumber(@PathVariable Long id,
+        @RequestBody String trackingNumber) {
+        tradeService.updateForwardingTrackingNumber(id, trackingNumber);
+    }
+
+    @LoginCheck(authority = UserLevel.AUTH)
+    @PatchMapping("{id}/purchase-confirmation")
+    public void ConfirmPurchase(@PathVariable Long id, @CurrentUser String email) {
+        tradeService.confirmPurchase(id, email);
+    }
 }

--- a/src/main/java/com/flab/shoeauction/domain/trade/Trade.java
+++ b/src/main/java/com/flab/shoeauction/domain/trade/Trade.java
@@ -117,10 +117,6 @@ public class Trade extends BaseTimeEntity {
         this.receivingTrackingNumber = trackingNumber;
     }
 
-    public void updateForwardingTrackingNumber(String trackingNumber) {
-        this.forwardingTrackingNumber = trackingNumber;
-    }
-
     public void updateReturnTrackingNumber(String trackingNumber) {
         this.returnTrackingNumber = trackingNumber;
     }
@@ -137,6 +133,10 @@ public class Trade extends BaseTimeEntity {
         return seller.isCurrentEmail(email);
     }
 
+    public boolean isBuyersEmail(String email) {
+        return buyer.isCurrentEmail(email);
+    }
+
     public void recoverBuyerPoints(Long price) {
         buyer.chargingPoint(price);
     }
@@ -144,12 +144,20 @@ public class Trade extends BaseTimeEntity {
     public boolean isPurchaseBid() {
         return buyer != null;
     }
-  
-     public void cancelBecauseOfInspection(String reason) {
+
+    public void cancelBecauseOfInspection(String reason) {
         this.cancelReason = reason;
         this.status = TradeStatus.CANCEL;
         buyer.chargingPoint(price);
     }
 
-  
+    public void updateStatusShipping(String trackingNumber) {
+        this.forwardingTrackingNumber = trackingNumber;
+        this.status = TradeStatus.SHIPPING;
+    }
+
+    public void endTrade() {
+        this.status = TradeStatus.TRADE_COMPLETE;
+        seller.chargingPoint(this.price);
+    }
 }

--- a/src/main/java/com/flab/shoeauction/domain/trade/TradeStatus.java
+++ b/src/main/java/com/flab/shoeauction/domain/trade/TradeStatus.java
@@ -7,7 +7,6 @@ package com.flab.shoeauction.domain.trade;
  *     PRE_INSPECTION: 검수 대기
  *     PRE_SHIPMENT: 구매자 발송 대기
  *     SHIPPING: 배송중(회사 -> 구매자)
- *     SHIPMENT_COMPLETE: 배송 완료
  *     TRADE_COMPLETE: 거래 완료
  *     CANCEL: 취소(판매자가 기간 내 상품 미발송 및 검수 탈락)
  */
@@ -19,7 +18,6 @@ public enum TradeStatus {
     PRE_INSPECTION,
     PRE_SHIPMENT,
     SHIPPING,
-    SHIPMENT_COMPLETE,
     TRADE_COMPLETE,
     CANCEL
 }

--- a/src/main/java/com/flab/shoeauction/service/TradeService.java
+++ b/src/main/java/com/flab/shoeauction/service/TradeService.java
@@ -133,6 +133,7 @@ public class TradeService {
 
         tradeRepository.deleteById(trade.getId());
     }
+
     // 판매자가 회사에 상품 발송 후 운송장 번호를 입력 시 입고 대기로 상태 변경
     @Transactional
     public void updateReceivingTrackingNumber(Long tradeId, String email, String trackingNumber) {
@@ -178,5 +179,23 @@ public class TradeService {
     @Transactional
     public boolean hasUsersProgressingTrade(User user) {
         return tradeRepository.existsProgressingByUser(user);
+    }
+
+    @Transactional
+    public void updateForwardingTrackingNumber(Long tradeId, String trackingNumber) {
+        Trade trade = tradeRepository.findById(tradeId).orElseThrow();
+
+        trade.updateStatusShipping(trackingNumber);
+    }
+
+    @Transactional
+    public void confirmPurchase(Long tradeId, String email) {
+        Trade trade = tradeRepository.findById(tradeId).orElseThrow();
+
+        if (!trade.isBuyersEmail(email)) {
+            throw new NotAuthorizedException("해당 거래의 구매자만 접근 가능합니다.");
+        }
+
+        trade.endTrade();
     }
 }

--- a/src/test/java/com/flab/shoeauction/service/TradeServiceTest.java
+++ b/src/test/java/com/flab/shoeauction/service/TradeServiceTest.java
@@ -5,6 +5,8 @@ import static com.flab.shoeauction.domain.trade.TradeStatus.PRE_CONCLUSION;
 import static com.flab.shoeauction.domain.trade.TradeStatus.PRE_INSPECTION;
 import static com.flab.shoeauction.domain.trade.TradeStatus.PRE_SHIPMENT;
 import static com.flab.shoeauction.domain.trade.TradeStatus.PRE_WAREHOUSING;
+import static com.flab.shoeauction.domain.trade.TradeStatus.SHIPPING;
+import static com.flab.shoeauction.domain.trade.TradeStatus.TRADE_COMPLETE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -563,5 +565,35 @@ class TradeServiceTest {
         tradeService.updateReturnTrackingNumber(tradeId, trackingNumber);
 
         assertThat(trade.getReturnTrackingNumber()).isEqualTo(trackingNumber);
+    }
+
+    @DisplayName("관리자가 상품 출고 후 운송장 번호를 입력한다.")
+    @Test
+    public void updateForwardingTrackingNumber() {
+        Trade trade = createConcludedBuyersTrade();
+        Long tradeId = trade.getId();
+        String trackingNumber = "192837465";
+        given(tradeRepository.findById(tradeId)).willReturn(Optional.of(trade));
+
+        tradeService.updateForwardingTrackingNumber(tradeId, trackingNumber);
+
+        assertThat(trade.getForwardingTrackingNumber()).isEqualTo(trackingNumber);
+        assertThat(trade.getStatus()).isEqualTo(SHIPPING);
+    }
+
+    @DisplayName("구매자의 구매 확정 요청이 성공한다.")
+    @Test
+    public void confirmPurchase() {
+        Trade trade = createConcludedBuyersTrade();
+        Long tradeId = trade.getId();
+        Long tradePrice = trade.getPrice();
+        String email = trade.getBuyer().getEmail();
+        Long preSellerPoint = trade.getSeller().getPoint();
+        given(tradeRepository.findById(tradeId)).willReturn(Optional.of(trade));
+
+        tradeService.confirmPurchase(tradeId, email);
+
+        assertThat(trade.getStatus()).isEqualTo(TRADE_COMPLETE);
+        assertThat(trade.getSeller().getPoint()).isEqualTo(preSellerPoint + tradePrice);
     }
 }


### PR DESCRIPTION
- 검수가 완료된 거래에 운송장 번호를 입력하면 tradeStatus가 `SHIPPING`으로 변경된다.
- 구매자가 구매 확정 처리를 할 경우 TradeStatus가 `TRADE_COMPLETE`으로 변경되며, 판매자에게 거래 대금(포인트)을 지불한다.
- (포인트 기록 영속화는 Issue 분리)