### PR TITLE
[#131] feat : 월별 거래량 조회

### DIFF
--- a/src/main/java/com/flab/shoeauction/controller/TradeApiController.java
+++ b/src/main/java/com/flab/shoeauction/controller/TradeApiController.java
@@ -5,13 +5,16 @@ import com.flab.shoeauction.common.annotation.LoginCheck;
 import com.flab.shoeauction.controller.dto.TradeDto;
 import com.flab.shoeauction.controller.dto.TradeDto.ChangeRequest;
 import com.flab.shoeauction.controller.dto.TradeDto.ImmediateTradeRequest;
+import com.flab.shoeauction.controller.dto.TradeDto.MonthlyTradingVolumesResponse;
 import com.flab.shoeauction.controller.dto.TradeDto.ReasonRequest;
 import com.flab.shoeauction.controller.dto.TradeDto.TrackingNumberRequest;
 import com.flab.shoeauction.controller.dto.TradeDto.TradeInfoResponse;
+import com.flab.shoeauction.controller.dto.TradeDto.TradeMonthSearchCondition;
 import com.flab.shoeauction.controller.dto.TradeDto.TradeResource;
 import com.flab.shoeauction.controller.dto.TradeDto.TradeSearchCondition;
 import com.flab.shoeauction.domain.users.common.UserLevel;
 import com.flab.shoeauction.service.TradeService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -126,5 +129,11 @@ public class TradeApiController {
     public Page<TradeInfoResponse> getTradeInfos(TradeSearchCondition tradeSearchCondition,
         Pageable pageable) {
         return tradeService.getTradeInfos(tradeSearchCondition, pageable);
+    }
+
+    @LoginCheck(authority =UserLevel.ADMIN)
+    @GetMapping("/month-volumes")
+    public List<MonthlyTradingVolumesResponse> getMonthVolumes(TradeMonthSearchCondition tradeMonthSearchCondition) {
+        return tradeService.getMonthlyTradingVolumes(tradeMonthSearchCondition);
     }
 }

--- a/src/main/java/com/flab/shoeauction/controller/dto/TradeDto.java
+++ b/src/main/java/com/flab/shoeauction/controller/dto/TradeDto.java
@@ -176,6 +176,7 @@ public class TradeDto {
     @Getter
     @NoArgsConstructor
     public static class TradeInfoResponse {
+
         private Long id;
         private TradeStatus status;
 
@@ -189,6 +190,7 @@ public class TradeDto {
     @Getter
     @NoArgsConstructor
     public static class TradeCompleteInfo {
+
         private double productSize;
         private Long price;
         private LocalDateTime completeTime;
@@ -200,4 +202,18 @@ public class TradeDto {
             this.completeTime = completeTime;
         }
     }
+
+    @Getter
+    @NoArgsConstructor
+    public static class TradeMonthSearchCondition {
+        private String year;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class MonthlyTradingVolumesResponse {
+        private String date;
+        private Long count;
+    }
 }
+

--- a/src/main/java/com/flab/shoeauction/domain/trade/SearchTradeRepository.java
+++ b/src/main/java/com/flab/shoeauction/domain/trade/SearchTradeRepository.java
@@ -1,8 +1,11 @@
 package com.flab.shoeauction.domain.trade;
 
+import com.flab.shoeauction.controller.dto.TradeDto.MonthlyTradingVolumesResponse;
 import com.flab.shoeauction.controller.dto.TradeDto.TradeInfoResponse;
+import com.flab.shoeauction.controller.dto.TradeDto.TradeMonthSearchCondition;
 import com.flab.shoeauction.controller.dto.TradeDto.TradeSearchCondition;
 import com.flab.shoeauction.domain.users.user.User;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -10,5 +13,9 @@ public interface SearchTradeRepository {
 
     boolean existsProgressingByUser(User user);
 
-    Page<TradeInfoResponse> searchByTradeStatusAndTradeId(TradeSearchCondition searchCondition, Pageable pageable);
+    Page<TradeInfoResponse> searchByTradeStatusAndTradeId(TradeSearchCondition searchCondition,
+        Pageable pageable);
+
+    List<MonthlyTradingVolumesResponse> searchTradeVolumeByMonth(
+        TradeMonthSearchCondition tradeMonthSearchCondition);
 }

--- a/src/main/java/com/flab/shoeauction/service/TradeService.java
+++ b/src/main/java/com/flab/shoeauction/service/TradeService.java
@@ -7,8 +7,10 @@ import static com.flab.shoeauction.domain.trade.TradeStatus.PRE_WAREHOUSING;
 import com.flab.shoeauction.controller.dto.ProductDto.ProductInfoByTrade;
 import com.flab.shoeauction.controller.dto.TradeDto.ChangeRequest;
 import com.flab.shoeauction.controller.dto.TradeDto.ImmediateTradeRequest;
+import com.flab.shoeauction.controller.dto.TradeDto.MonthlyTradingVolumesResponse;
 import com.flab.shoeauction.controller.dto.TradeDto.SaveRequest;
 import com.flab.shoeauction.controller.dto.TradeDto.TradeInfoResponse;
+import com.flab.shoeauction.controller.dto.TradeDto.TradeMonthSearchCondition;
 import com.flab.shoeauction.controller.dto.TradeDto.TradeResource;
 import com.flab.shoeauction.controller.dto.TradeDto.TradeSearchCondition;
 import com.flab.shoeauction.controller.dto.UserDto.TradeUserInfo;
@@ -23,6 +25,7 @@ import com.flab.shoeauction.domain.users.user.UserRepository;
 import com.flab.shoeauction.exception.user.NotAuthorizedException;
 import com.flab.shoeauction.exception.user.UserNotFoundException;
 import com.flab.shoeauction.service.message.MessageService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.domain.Page;
@@ -217,5 +220,10 @@ public class TradeService {
         trade.endTrade();
 
         pointService.salesPointReceive(trade.getSeller(), trade.getPrice());
+    }
+
+    public List<MonthlyTradingVolumesResponse> getMonthlyTradingVolumes(
+        TradeMonthSearchCondition tradeMonthSearchCondition) {
+        return tradeRepository.searchTradeVolumeByMonth(tradeMonthSearchCondition);
     }
 }


### PR DESCRIPTION
1. ADMIN 권한을 가진 사용자가 월별 거래량 (status가 `trade_complete`)을 조회하는 기능으로 조회 결과는 아래와 같습니다.
![image](https://user-images.githubusercontent.com/39195377/120108812-b70e5f80-c1a1-11eb-8ee6-ca889b232e5e.png)



issue number : #131